### PR TITLE
fix: disable react sort prop types

### DIFF
--- a/@ornikar/eslint-config/rules/react.js
+++ b/@ornikar/eslint-config/rules/react.js
@@ -21,7 +21,7 @@ module.exports = {
 
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
     'react/sort-prop-types': [
-      'error',
+      'off',
       {
         noSortAlphabetically: true,
         requiredFirst: true,


### PR DESCRIPTION
noSortAlphabetically option is not yet released