### PR TITLE
fix: disable sort prop types required first

### DIFF
--- a/@ornikar/eslint-config/rules/react.js
+++ b/@ornikar/eslint-config/rules/react.js
@@ -24,7 +24,7 @@ module.exports = {
       'error',
       {
         noSortAlphabetically: true,
-        requiredFirst: true,
+        requiredFirst: false,
         callbacksLast: true,
       },
     ],


### PR DESCRIPTION
We can still reenable it later with a breaking change