### PR TITLE
feat: disable jsx-curly-brace-presence [no issue]

### DIFF
--- a/@ornikar/eslint-config/rules/react.js
+++ b/@ornikar/eslint-config/rules/react.js
@@ -81,5 +81,8 @@ module.exports = {
 
     // project should use babel-plugin-transform-react-remove-prop-types
     'react/forbid-foreign-prop-types': 'off',
+
+    // autofix handles quotes incorrectly
+    'react/jsx-curly-brace-presence': 'off',
   },
 };


### PR DESCRIPTION
J'ai essayé mettre des options à la règle pour forcer la présence des accolades pour les childrens, mais ça fonctionne pas tout à fait comme espéré : 

![screen shot 2018-10-29 at 18 27 35](https://user-images.githubusercontent.com/18282455/47668289-5319f980-dba8-11e8-939c-1c83d29d9898.png)
 
