### PR TITLE
fix: max-lines triggers warning instead of error

### DIFF
--- a/@ornikar/eslint-config/rules/code-quality.js
+++ b/@ornikar/eslint-config/rules/code-quality.js
@@ -7,7 +7,7 @@ module.exports = {
     'max-lines': [
       'warn',
       {
-        max: 200,
+        max: 120,
         skipBlankLines: false,
         skipComments: false,
       },

--- a/@ornikar/eslint-config/rules/code-quality.js
+++ b/@ornikar/eslint-config/rules/code-quality.js
@@ -5,7 +5,7 @@ module.exports = {
     complexity: ['warn', { max: 10 }],
     'max-depth': ['warn', 6],
     'max-lines': [
-      'error',
+      'warn',
       {
         max: 200,
         skipBlankLines: false,


### PR DESCRIPTION
A mon sens, cette règle a pour but de suggérer au gentil développeur qu'il pourrait être intéressant de factoriser/regrouper. L'erreur est donc trop forte et un warning serait plus pertinent.