### PR TITLE
fix: remove postcss production

### DIFF
--- a/@ornikar/postcss-config/index.js
+++ b/@ornikar/postcss-config/index.js
@@ -20,9 +20,3 @@ exports.customMediaPlugin = customMediaOptions =>
   require('postcss-custom-media')(customMediaOptions);
 
 exports.autoprefixerPlugin = () => require('autoprefixer');
-
-exports.productionPlugins = () => [
-  require('cssnano')({
-    preset: 'default',
-  }),
-];

--- a/@ornikar/postcss-config/package.json
+++ b/@ornikar/postcss-config/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "autoprefixer": "^9.2.0",
-    "cssnano": "^4.1.4",
     "postcss-custom-media": "^7.0.6",
     "postcss-custom-properties": "^8.0.8",
     "postcss-nested": "^4.1.0"


### PR DESCRIPTION
BREAKING CHANGE: removed export productionPlugins

cssnano should be called with https://github.com/NMFR/optimize-css-assets-webpack-plugin