### PR TITLE
feat(renovate-config): disable rebase stale pr

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -11,6 +11,7 @@
   "renovate-config": {
     "default": {
       "extends": ["schedule:earlyMondays"],
+      "rebaseStalePrs": false,
       "packageRules": [
         {
           "groupName": "Shared Configs Ornikar",


### PR DESCRIPTION
Avoid a lot of workflows during the day
We can still do it with the checkbox in the PR when we need it :)