### PR TITLE
feat: Regroup all minor updates in same PR

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -14,6 +14,10 @@
       "rebaseStalePrs": false,
       "packageRules": [
         {
+          "groupName": "all",
+          "updateTypes": ["minor"]
+        },
+        {
           "groupName": "Shared Configs Ornikar",
           "packageNames": [
             "@ornikar/browserslit-config",


### PR DESCRIPTION
A discuter, mais je pense que ça serait plus simple si toutes les updates mineurs étaient faites dans une même pull request.

La syntaxe viens de : https://renovatebot.com/docs/faq/  -> "Use a single branch/PR for all dependency upgrades"

Il y a moyen de 'tester' les règles qu'on écrit (Depuis l'app github peut-être ? ) Parce que là je suis vraiment pas sur que ça soit bon.

