### PR TITLE
feat: rebase stale pr on early mondays [no issue]

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -11,7 +11,8 @@
   "renovate-config": {
     "default": {
       "extends": ["schedule:earlyMondays"],
-      "rebaseStalePrs": false,
+      "rebaseStalePrs": true,
+      "updateNotScheduled": false,
       "packageRules": [
         {
           "groupName": "Shared Configs Ornikar",


### PR DESCRIPTION
J'avais trouvé cette issue suite à une recherche google :

https://github.com/renovatebot/renovate/issues/2714

Je pense pas qu'on puisse faire de distinction entre un schedule d'ouverture de PR et un schedule de rebase.

Avec ce que j'ajoute, l'effet escompté est que : 
- Les PR de renovate sont toujours ouverte `earlyMondays` 
- Les PR ne sont pas mise à jour automatique en dehors des `earlyMondays` 
- Les PR de la semaine précédentes sont mise à jour lors des `earlyMondays`

Les PR ne sont pas censées resté ouvertes plus d'une semaine, mais bon ça arrive et ça arrivera encore je pense.
