### PR TITLE
feat: group packages renovate ONK-3275

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -57,6 +57,15 @@
           "major": {
             "automerge": false
           }
+        },
+        {
+          "groupName": "babel packages",
+          "excludePackageNames": ["babel-eslint"],
+          "packagePatterns": ["^babel", "^@babel"],
+          "automerge": false,
+          "major": {
+            "automerge": false
+          }
         }
       ]
     }

--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -10,14 +10,10 @@
   },
   "renovate-config": {
     "default": {
-      "extends": [
-        "schedule:earlyMondays"
-      ],
+      "extends": ["schedule:earlyMondays"],
       "rebaseStalePrs": true,
       "updateNotScheduled": false,
-      "postUpdateOptions": [
-        "yarnDedupeHighest"
-      ],
+      "postUpdateOptions": ["yarnDedupeHighest"],
       "packageRules": [
         {
           "groupName": "Shared Configs Ornikar",
@@ -31,28 +27,25 @@
             "@ornikar/renovate-config",
             "@ornikar/stylelint-config"
           ],
-          "schedule": [
-            "at any time"
-          ]
+          "schedule": ["at any time"]
         },
         {
-          "packagePatterns": [
-            "^@ornikar"
-          ],
-          "schedule": [
-            "at any time"
-          ]
+          "packagePatterns": ["^@ornikar"],
+          "schedule": ["at any time"]
         },
         {
           "groupName": "eslint packages",
-          "packageNames": [
-            "babel-eslint",
-            "prettier"
-          ],
-          "packagePatterns": [
-            "^eslint"
-          ],
+          "packageNames": ["babel-eslint", "prettier"],
+          "packagePatterns": ["^eslint"],
           "automerge": true,
+          "major": {
+            "automerge": false
+          }
+        },
+        {
+          "groupName": "storybook packages",
+          "packagePatterns": ["^@storybook"],
+          "automerge": false,
           "major": {
             "automerge": false
           }

--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -43,13 +43,9 @@
           }
         },
         {
-          "groupName": "storybook packages",
-          "packagePatterns": ["^@storybook"]
-        },
-        {
-          "groupName": "babel packages",
+          "groupName": "babel community packages",
           "excludePackageNames": ["babel-eslint"],
-          "packagePatterns": ["^babel", "^@babel"]
+          "packagePatterns": ["^babel"]
         },
         {
           "groupName": "rollup packages",

--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -49,6 +49,14 @@
           "major": {
             "automerge": false
           }
+        },
+        {
+          "groupName": "react packages",
+          "packageNames": ["react", "react-dom"],
+          "automerge": false,
+          "major": {
+            "automerge": false
+          }
         }
       ]
     }

--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -44,36 +44,16 @@
         },
         {
           "groupName": "storybook packages",
-          "packagePatterns": ["^@storybook"],
-          "automerge": false,
-          "major": {
-            "automerge": false
-          }
-        },
-        {
-          "groupName": "react packages",
-          "packageNames": ["react", "react-dom"],
-          "automerge": false,
-          "major": {
-            "automerge": false
-          }
+          "packagePatterns": ["^@storybook"]
         },
         {
           "groupName": "babel packages",
           "excludePackageNames": ["babel-eslint"],
-          "packagePatterns": ["^babel", "^@babel"],
-          "automerge": false,
-          "major": {
-            "automerge": false
-          }
+          "packagePatterns": ["^babel", "^@babel"]
         },
         {
           "groupName": "rollup packages",
-          "packagePatterns": ["^rollup"],
-          "automerge": false,
-          "major": {
-            "automerge": false
-          }
+          "packagePatterns": ["^rollup"]
         }
       ]
     }

--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -66,6 +66,14 @@
           "major": {
             "automerge": false
           }
+        },
+        {
+          "groupName": "rollup packages",
+          "packagePatterns": ["^rollup"],
+          "automerge": false,
+          "major": {
+            "automerge": false
+          }
         }
       ]
     }


### PR DESCRIPTION
Permet de créer des groupes de packages pour renovate et éviter d'avoir 5 PR pour eslint/babel/storybook.

J'ai voulu rajouter webpack mais c'est utilisé que sur la LA. Et y a pas vraiment de convention de ming.. Est ce que je le rajoute quand même ?