### PR TITLE
refactor: eslint-config dependencies ONK-3265

### DIFF
--- a/@ornikar/eslint-config-babel/README.md
+++ b/@ornikar/eslint-config-babel/README.md
@@ -12,5 +12,5 @@ Also see:
 - [@ornikar/eslint-config-typescript](https://github.com/ornikar/shared-configs/tree/master/%40ornikar/eslint-config-typescript)
 - [@ornikar/eslint-config-typescript-react](https://github.com/ornikar/shared-configs/tree/master/%40ornikar/eslint-config-typescript-react)
 
-1. `npm install --save-dev eslint @ornikar/eslint-config-babel eslint-plugin-filenames eslint-plugin-import eslint-plugin-prefer-class-properties eslint-plugin-prettier eslint-plugin-unicorn`
+1. `npm install --save-dev eslint @ornikar/eslint-config-babel`
 2. Add `"extends": "@ornikar/eslint-config-babel"` to your eslint config

--- a/@ornikar/eslint-config-babel/package.json
+++ b/@ornikar/eslint-config-babel/package.json
@@ -17,5 +17,11 @@
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-babel": "5.3.0",
     "eslint-plugin-prefer-class-properties": "1.0.0"
+  },
+  "peerDependencies": {
+    "eslint": "^5.10.0"
+  },
+  "devDependencies": {
+    "eslint": "5.16.0"
   }
 }

--- a/@ornikar/eslint-config-babel/package.json
+++ b/@ornikar/eslint-config-babel/package.json
@@ -12,15 +12,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@ornikar/eslint-config": "^8.0.4",
-    "babel-eslint": "^10.0.1",
-    "eslint-config-airbnb-base": "13.1.0"
-  },
-  "peerDependencies": {
-    "eslint-plugin-babel": "^5.3.0",
-    "eslint-plugin-prefer-class-properties": "^1.0.0"
-  },
-  "devDependencies": {
+    "@ornikar/eslint-config": "8.0.4",
+    "babel-eslint": "10.0.1",
+    "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-babel": "5.3.0",
     "eslint-plugin-prefer-class-properties": "1.0.0"
   }

--- a/@ornikar/eslint-config-babel/package.json
+++ b/@ornikar/eslint-config-babel/package.json
@@ -12,11 +12,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@ornikar/eslint-config": "8.0.4",
-    "babel-eslint": "10.0.1",
-    "eslint-config-airbnb-base": "13.1.0",
-    "eslint-plugin-babel": "5.3.0",
-    "eslint-plugin-prefer-class-properties": "1.0.0"
+    "@ornikar/eslint-config": "^8.0.4",
+    "babel-eslint": "^10.0.1",
+    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-plugin-babel": "^5.3.0",
+    "eslint-plugin-prefer-class-properties": "^1.0.0"
   },
   "peerDependencies": {
     "eslint": "^5.10.0"

--- a/@ornikar/eslint-config-node/README.md
+++ b/@ornikar/eslint-config-node/README.md
@@ -14,15 +14,15 @@ Also see:
 
 ### node without babel or typescript
 
-1. `npm install --save-dev eslint @ornikar/eslint-config eslint-plugin-filenames eslint-plugin-prettier eslint-plugin-unicorn @ornikar/eslint-config-node eslint-plugin-node`
+1. `npm install --save-dev eslint @ornikar/eslint-config @ornikar/eslint-config-node`
 2. Add `"extends": ["@ornikar/eslint-config", "@ornikar/eslint-config-node"]` to your eslint config
 
 ### node with babel
 
-1. `npm install --save-dev eslint @ornikar/eslint-config-babel eslint-plugin-filenames eslint-plugin-import eslint-plugin-prettier eslint-plugin-unicorn @ornikar/eslint-config-node eslint-plugin-node`
+1. `npm install --save-dev eslint @ornikar/eslint-config-babel @ornikar/eslint-config-node`
 2. Add `"extends": ["@ornikar/eslint-config-babel", "@ornikar/eslint-config-node""]` to your eslint config
 
 ### node with typescript
 
-1. `npm install --save-dev eslint @ornikar/eslint-config-typescript eslint-plugin-filenames eslint-plugin-import eslint-plugin-prefer-class-properties eslint-plugin-prettier eslint-plugin-unicorn @typescript-eslint/eslint-plugin @typescript-eslint/parser @ornikar/eslint-config-node eslint-plugin-node`
+1. `npm install --save-dev eslint @ornikar/eslint-config-typescript @ornikar/eslint-config-node`
 2. Add `"extends": ["@ornikar/eslint-config-typescript", "@ornikar/eslint-config-node""]` to your eslint config

--- a/@ornikar/eslint-config-node/package.json
+++ b/@ornikar/eslint-config-node/package.json
@@ -11,11 +11,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
-    "eslint-plugin-node": "^8.0.1",
-    "eslint-plugin-unicorn": "^8.0.0"
-  },
-  "devDependencies": {
+  "dependencies": {
     "eslint-plugin-node": "8.0.1",
     "eslint-plugin-unicorn": "8.0.1"
   }

--- a/@ornikar/eslint-config-node/package.json
+++ b/@ornikar/eslint-config-node/package.json
@@ -12,8 +12,8 @@
     "access": "public"
   },
   "dependencies": {
-    "eslint-plugin-node": "8.0.1",
-    "eslint-plugin-unicorn": "8.0.1"
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-unicorn": "^8.0.1"
   },
   "peerDependencies": {
     "eslint": "^5.10.0"

--- a/@ornikar/eslint-config-node/package.json
+++ b/@ornikar/eslint-config-node/package.json
@@ -14,5 +14,11 @@
   "dependencies": {
     "eslint-plugin-node": "8.0.1",
     "eslint-plugin-unicorn": "8.0.1"
+  },
+  "peerDependencies": {
+    "eslint": "^5.10.0"
+  },
+  "devDependencies": {
+    "eslint": "5.16.0"
   }
 }

--- a/@ornikar/eslint-config-react/README.md
+++ b/@ornikar/eslint-config-react/README.md
@@ -14,10 +14,10 @@ Also see:
 
 ### react
 
-1. `npm install --save-dev eslint babel-eslint @ornikar/eslint-config-babel eslint-plugin-filenames eslint-plugin-import eslint-plugin-prettier eslint-plugin-unicorn @ornikar/eslint-config-react eslint-plugin-react eslint-plugin-jsx-a11y eslint-plugin-react-hooks`
-2. Add `"extends": ["@ornikar/eslint-config-babel", "@ornikar/eslint-config-react"]` to your eslint config
+1. `npm install --save-dev eslint @ornikar/eslint-config-react`
+2. Add `"extends": ["@ornikar/eslint-config-react"]` to your eslint config
 
 ### react-native
 
-1. `npm install --save-dev eslint babel-eslint @ornikar/eslint-config-babel eslint-plugin-filenames eslint-plugin-import eslint-plugin-prettier eslint-plugin-unicorn @ornikar/eslint-config-react eslint-plugin-react eslint-plugin-jsx-a11y eslint-plugin-react-hooks`
-2. Add `"extends": ["@ornikar/eslint-config-babel", "@ornikar/eslint-config-react/react-native"]` to your eslint config
+1. `npm install --save-dev eslint @ornikar/eslint-config-react`
+2. Add `"extends": ["@ornikar/eslint-config-react/react-native"]` to your eslint config

--- a/@ornikar/eslint-config-react/index.js
+++ b/@ornikar/eslint-config-react/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   extends: [
+    '@ornikar/eslint-config-babel',
     'eslint-config-airbnb/rules/react',
     'eslint-config-airbnb/rules/react-a11y',
     'eslint-config-prettier',

--- a/@ornikar/eslint-config-react/package.json
+++ b/@ornikar/eslint-config-react/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@ornikar/eslint-config-babel": "8.0.4",
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-prettier": "4.0.0",
     "eslint-plugin-react-hooks": "1.3.0"

--- a/@ornikar/eslint-config-react/package.json
+++ b/@ornikar/eslint-config-react/package.json
@@ -12,15 +12,14 @@
     "access": "public"
   },
   "dependencies": {
-    "eslint-config-airbnb": "^17.1.0",
-    "eslint-config-prettier": "^4.0.0"
+    "eslint-config-airbnb": "17.1.0",
+    "eslint-config-prettier": "4.0.0",
+    "eslint-plugin-react-hooks": "1.3.0"
   },
   "peerDependencies": {
-    "eslint": "^5.10.0",
-    "eslint-plugin-react-hooks": "^1.3.0"
+    "eslint": "^5.10.0"
   },
   "devDependencies": {
-    "eslint": "5.16.0",
-    "eslint-plugin-react-hooks": "1.6.0"
+    "eslint": "5.16.0"
   }
 }

--- a/@ornikar/eslint-config-react/package.json
+++ b/@ornikar/eslint-config-react/package.json
@@ -12,10 +12,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@ornikar/eslint-config-babel": "8.0.4",
-    "eslint-config-airbnb": "17.1.0",
-    "eslint-config-prettier": "4.0.0",
-    "eslint-plugin-react-hooks": "1.3.0"
+    "@ornikar/eslint-config-babel": "^8.0.4",
+    "eslint-config-airbnb": "^17.1.0",
+    "eslint-config-prettier": "^4.0.0",
+    "eslint-plugin-react-hooks": "^1.3.0"
   },
   "peerDependencies": {
     "eslint": "^5.10.0"

--- a/@ornikar/eslint-config-typescript-react/README.md
+++ b/@ornikar/eslint-config-typescript-react/README.md
@@ -12,5 +12,5 @@ Also see:
 - [@ornikar/eslint-config-react](https://github.com/ornikar/shared-configs/tree/master/%40ornikar/eslint-config-react)
 - [@ornikar/eslint-config-typescript](https://github.com/ornikar/shared-configs/tree/master/%40ornikar/eslint-config-typescript)
 
-1. `npm install --save-dev eslint @ornikar/eslint-config-typescript eslint-plugin-filenames eslint-plugin-import eslint-plugin-prefer-class-properties eslint-plugin-prettier eslint-plugin-unicorn @typescript-eslint/eslint-plugin @typescript-eslint/parser @ornikar/eslint-config-typescript-react eslint-plugin-react eslint-plugin-jsx-a11y eslint-plugin-react-hooks`
+1. `npm install --save-dev eslint @ornikar/eslint-config-typescript`
 2. Add `"extends": "@ornikar/eslint-config-typescript-react"` to your eslint config

--- a/@ornikar/eslint-config-typescript-react/package.json
+++ b/@ornikar/eslint-config-typescript-react/package.json
@@ -12,8 +12,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@ornikar/eslint-config-react": "8.0.3",
-    "eslint-config-prettier": "4.0.0"
+    "@ornikar/eslint-config-react": "^8.0.3",
+    "eslint-config-prettier": "^4.0.0"
   },
   "peerDependencies": {
     "eslint": "^5.10.0"

--- a/@ornikar/eslint-config-typescript-react/package.json
+++ b/@ornikar/eslint-config-typescript-react/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@ornikar/eslint-config-react": "^8.0.3",
-    "eslint-config-prettier": "^4.0.0"
+    "eslint-config-prettier": "4.0.0"
   },
   "peerDependencies": {
     "eslint": "^5.10.0"

--- a/@ornikar/eslint-config-typescript-react/package.json
+++ b/@ornikar/eslint-config-typescript-react/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@ornikar/eslint-config-react": "^8.0.3",
+    "@ornikar/eslint-config-react": "8.0.3",
     "eslint-config-prettier": "4.0.0"
   },
   "peerDependencies": {

--- a/@ornikar/eslint-config-typescript/README.md
+++ b/@ornikar/eslint-config-typescript/README.md
@@ -12,5 +12,5 @@ Also see:
 - [@ornikar/eslint-config-react](https://github.com/ornikar/shared-configs/tree/master/%40ornikar/eslint-config-react)
 - [@ornikar/eslint-config-typescript-react](https://github.com/ornikar/shared-configs/tree/master/%40ornikar/eslint-config-typescript-react)
 
-1. `npm install --save-dev eslint @ornikar/eslint-config-typescript eslint-plugin-filenames eslint-plugin-import eslint-plugin-prefer-class-properties eslint-plugin-prettier eslint-plugin-unicorn @typescript-eslint/eslint-plugin @typescript-eslint/parser`
+1. `npm install --save-dev eslint @ornikar/eslint-config-typescript`
 2. Add `"extends": "@ornikar/eslint-config-typescript"` to your eslint config

--- a/@ornikar/eslint-config-typescript/package.json
+++ b/@ornikar/eslint-config-typescript/package.json
@@ -13,10 +13,10 @@
   },
   "dependencies": {
     "@ornikar/eslint-config": "^8.0.4",
-    "eslint-config-airbnb-base": "13.1.0",
-    "eslint-config-prettier": "4.0.0",
-    "@typescript-eslint/eslint-plugin": "1.4.2",
-    "@typescript-eslint/parser": "1.4.2"
+    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-config-prettier": "^4.0.0",
+    "@typescript-eslint/eslint-plugin": "^1.4.2",
+    "@typescript-eslint/parser": "^1.4.2"
   },
   "peerDependencies": {
     "eslint": "^5.10.0"

--- a/@ornikar/eslint-config-typescript/package.json
+++ b/@ornikar/eslint-config-typescript/package.json
@@ -13,17 +13,15 @@
   },
   "dependencies": {
     "@ornikar/eslint-config": "^8.0.4",
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-config-prettier": "^4.0.0"
+    "eslint-config-airbnb-base": "13.1.0",
+    "eslint-config-prettier": "4.0.0",
+    "@typescript-eslint/eslint-plugin": "1.4.2",
+    "@typescript-eslint/parser": "1.4.2"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^1.4.2",
-    "@typescript-eslint/parser": "^1.4.2",
     "eslint": "^5.10.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "1.5.0",
-    "@typescript-eslint/parser": "1.5.0",
     "eslint": "5.16.0"
   }
 }

--- a/@ornikar/eslint-config/README.md
+++ b/@ornikar/eslint-config/README.md
@@ -14,5 +14,5 @@ Also see:
 - [@ornikar/eslint-config-typescript](https://github.com/ornikar/shared-configs/tree/master/%40ornikar/eslint-config-typescript)
 - [@ornikar/eslint-config-typescript-react](https://github.com/ornikar/shared-configs/tree/master/%40ornikar/eslint-config-typescript-react)
 
-1. `npm install --save-dev eslint @ornikar/eslint-config eslint-plugin-filenames eslint-plugin-prettier eslint-plugin-unicorn`
+1. `npm install --save-dev eslint @ornikar/eslint-config`
 2. Add `"extends": "@ornikar/eslint-config"` to your eslint config

--- a/@ornikar/eslint-config/package.json
+++ b/@ornikar/eslint-config/package.json
@@ -12,26 +12,21 @@
     "access": "public"
   },
   "dependencies": {
-    "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-config-prettier": "^4.0.0"
+    "eslint-config-airbnb-base": "13.1.0",
+    "eslint-config-airbnb": "17.1.0",
+    "eslint-config-prettier": "4.0.0",
+    "eslint-plugin-filenames": "1.3.2",
+    "eslint-plugin-import": "2.16.0",
+    "eslint-plugin-jsx-a11y": "6.2.1",
+    "eslint-plugin-prettier": "3.0.0",
+    "eslint-plugin-unicorn": "8.0.0"
   },
   "peerDependencies": {
     "eslint": "^5.10.0",
-    "eslint-plugin-filenames": "^1.3.2",
-    "eslint-plugin-prettier": "^3.0.0",
-    "eslint-plugin-unicorn": "^8.0.0",
     "prettier": "^1.15.3"
   },
   "devDependencies": {
     "eslint": "5.16.0",
-    "eslint-config-airbnb": "17.1.0",
-    "eslint-plugin-filenames": "1.3.2",
-    "eslint-plugin-import": "2.16.0",
-    "eslint-plugin-jsx-a11y": "6.2.1",
-    "eslint-plugin-node": "8.0.1",
-    "eslint-plugin-prettier": "3.0.1",
-    "eslint-plugin-react": "7.12.4",
-    "eslint-plugin-unicorn": "8.0.1",
     "prettier": "1.16.4"
   }
 }

--- a/@ornikar/eslint-config/package.json
+++ b/@ornikar/eslint-config/package.json
@@ -19,7 +19,7 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-jsx-a11y": "6.2.1",
     "eslint-plugin-prettier": "3.0.0",
-    "eslint-plugin-unicorn": "8.0.0"
+    "eslint-plugin-unicorn": "8.0.1"
   },
   "peerDependencies": {
     "eslint": "^5.10.0",

--- a/@ornikar/eslint-config/package.json
+++ b/@ornikar/eslint-config/package.json
@@ -12,14 +12,14 @@
     "access": "public"
   },
   "dependencies": {
-    "eslint-config-airbnb-base": "13.1.0",
-    "eslint-config-airbnb": "17.1.0",
-    "eslint-config-prettier": "4.0.0",
-    "eslint-plugin-filenames": "1.3.2",
-    "eslint-plugin-import": "2.16.0",
-    "eslint-plugin-jsx-a11y": "6.2.1",
-    "eslint-plugin-prettier": "3.0.0",
-    "eslint-plugin-unicorn": "8.0.1"
+    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-config-airbnb": "^17.1.0",
+    "eslint-config-prettier": "^4.0.0",
+    "eslint-plugin-filenames": "^1.3.2",
+    "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-jsx-a11y": "^6.2.1",
+    "eslint-plugin-prettier": "^3.0.0",
+    "eslint-plugin-unicorn": "^8.0.1"
   },
   "peerDependencies": {
     "eslint": "^5.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,29 +975,29 @@
     "@types/unist" "*"
     "@types/vfile-message" "*"
 
-"@typescript-eslint/eslint-plugin@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.5.0.tgz#85c509bcfc2eb35f37958fa677379c80b7a8f66f"
-  integrity sha512-TZ5HRDFz6CswqBUviPX8EfS+iOoGbclYroZKT3GWGYiGScX0qo6QjHc5uuM7JN920voP2zgCkHgF5SDEVlCtjQ==
+"@typescript-eslint/eslint-plugin@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.4.2.tgz#370bc32022d1cc884a5dcf62624ef2024182769d"
+  integrity sha512-6WInypy/cK4rM1dirKbD5p7iFW28DbSRKT/+PGn+DYzBWEvHq5KnZAqQ5cX25JBc0qMkFxJNxNfBbFXJyyzVcw==
   dependencies:
-    "@typescript-eslint/parser" "1.5.0"
-    "@typescript-eslint/typescript-estree" "1.5.0"
+    "@typescript-eslint/parser" "1.4.2"
+    "@typescript-eslint/typescript-estree" "1.4.2"
     requireindex "^1.2.0"
     tsutils "^3.7.0"
 
-"@typescript-eslint/parser@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.5.0.tgz#a96114d195dff2a49534e4c4850fb676f905a072"
-  integrity sha512-pRWTnJrnxuT0ragdY26hZL+bxqDd4liMlftpH2CBlMPryOIOb1J+MdZuw6R4tIu6bWVdwbHKPTs+Q34LuGvfGw==
+"@typescript-eslint/parser@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.4.2.tgz#acfdee2019958a41d308d768e53ded975ef90ce8"
+  integrity sha512-OqLkY9295DXXaWToItUv3olO2//rmzh6Th6Sc7YjFFEpEuennsm5zhygLLvHZjPxPlzrQgE8UDaOPurDylaUuw==
   dependencies:
-    "@typescript-eslint/typescript-estree" "1.5.0"
+    "@typescript-eslint/typescript-estree" "1.4.2"
     eslint-scope "^4.0.0"
     eslint-visitor-keys "^1.0.0"
 
-"@typescript-eslint/typescript-estree@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.5.0.tgz#986b356ecdf5a0c3bc9889d221802149cf5dbd4e"
-  integrity sha512-XqR14d4BcYgxcrpxIwcee7UEjncl9emKc/MgkeUfIk2u85KlsGYyaxC7Zxjmb17JtWERk/NaO+KnBsqgpIXzwA==
+"@typescript-eslint/typescript-estree@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.4.2.tgz#b16bc36c9a4748a7fca92cba4c2d73c5325c8a85"
+  integrity sha512-wKgi/w6k1v3R4b6oDc20cRWro2gBzp0wn6CAeYC8ExJMfvXMfiaXzw2tT9ilxdONaVWMCk7B9fMdjos7bF/CWw==
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
@@ -1286,7 +1286,7 @@ axobject-query@^2.0.2:
   dependencies:
     ast-types-flow "0.0.7"
 
-babel-eslint@^10.0.1:
+babel-eslint@10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
   integrity sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
@@ -2448,7 +2448,7 @@ eslint-config-airbnb-base@13.1.0, eslint-config-airbnb-base@^13.1.0:
     object.assign "^4.1.0"
     object.entries "^1.0.4"
 
-eslint-config-airbnb@17.1.0, eslint-config-airbnb@^17.1.0:
+eslint-config-airbnb@17.1.0:
   version "17.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-17.1.0.tgz#3964ed4bc198240315ff52030bf8636f42bc4732"
   integrity sha512-R9jw28hFfEQnpPau01NO5K/JWMGLi6aymiF6RsnMURjTk+MqZKllCqGK/0tOvHkPi/NWSSOU2Ced/GX++YxLnw==
@@ -2457,7 +2457,7 @@ eslint-config-airbnb@17.1.0, eslint-config-airbnb@^17.1.0:
     object.assign "^4.1.0"
     object.entries "^1.0.4"
 
-eslint-config-prettier@^4.0.0:
+eslint-config-prettier@4.0.0, eslint-config-prettier@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.0.0.tgz#16cedeea0a56e74de60dcbbe3be0ab2c645405b9"
   integrity sha512-kWuiJxzV5NwOwZcpyozTzDT5KJhBw292bbYro9Is7BWnbNMg15Gmpluc1CTetiCatF8DRkNvgPAOaSyg+bYr3g==
@@ -2495,7 +2495,7 @@ eslint-plugin-es@^1.3.1:
     eslint-utils "^1.3.0"
     regexpp "^2.0.0"
 
-eslint-plugin-filenames@1.3.2, eslint-plugin-filenames@^1.3.2:
+eslint-plugin-filenames@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz#7094f00d7aefdd6999e3ac19f72cea058e590cf7"
   integrity sha512-tqxJTiEM5a0JmRCUYQmxw23vtTxrb2+a3Q2mMOPhFxvt7ZQQJmdiuMby9B/vUAuVMghyP7oET+nIf6EO6CBd/w==
@@ -2554,19 +2554,26 @@ eslint-plugin-prefer-class-properties@1.0.0:
   dependencies:
     requireindex "~1.1.0"
 
-eslint-plugin-prettier@3.0.1, eslint-plugin-prettier@^3.0.0:
+eslint-plugin-prettier@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.0.tgz#f6b823e065f8c36529918cdb766d7a0e975ec30c"
+  integrity sha512-4g11opzhqq/8+AMmo5Vc2Gn7z9alZ4JqrbZ+D4i8KlSyxeQhZHlmIrY8U9Akf514MoEhogPa87Jgkq87aZ2Ohw==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-prettier@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz#19d521e3981f69dd6d14f64aec8c6a6ac6eb0b0d"
   integrity sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-hooks@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
-  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
+eslint-plugin-react-hooks@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.3.0.tgz#d73f1a61d8dd6a14f15159ab1c6e8e3aeabb6da8"
+  integrity sha512-hjgyNq0sfDXaLkXHkmo3vRh+p+42lwQIU3r56hVoomMYRMToJ2D/PGhwL2EPyB5ZEMlbLsRm3s5v4gm5FIjlvg==
 
-eslint-plugin-unicorn@8.0.1, eslint-plugin-unicorn@^8.0.0:
+eslint-plugin-unicorn@8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-8.0.1.tgz#9212c4d8dd729785db846db920148ca97d545696"
   integrity sha512-BIkPbCww71GZPnT1U4jzlNQyabmV7JlHu3qhCGLkZZKFp7jWkWdCQziadYdpLFLD5A+Z2nSi1LPe8/fkesvPVg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2212,13 +2212,6 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
-  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
-  dependencies:
-    esutils "^2.0.2"
-
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -2502,7 +2495,7 @@ eslint-plugin-es@^1.3.1:
     eslint-utils "^1.3.0"
     regexpp "^2.0.0"
 
-eslint-plugin-filenames@1.3.2:
+eslint-plugin-filenames@1.3.2, eslint-plugin-filenames@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz#7094f00d7aefdd6999e3ac19f72cea058e590cf7"
   integrity sha512-tqxJTiEM5a0JmRCUYQmxw23vtTxrb2+a3Q2mMOPhFxvt7ZQQJmdiuMby9B/vUAuVMghyP7oET+nIf6EO6CBd/w==
@@ -2561,7 +2554,7 @@ eslint-plugin-prefer-class-properties@1.0.0:
   dependencies:
     requireindex "~1.1.0"
 
-eslint-plugin-prettier@3.0.1:
+eslint-plugin-prettier@3.0.1, eslint-plugin-prettier@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz#19d521e3981f69dd6d14f64aec8c6a6ac6eb0b0d"
   integrity sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==
@@ -2573,20 +2566,7 @@ eslint-plugin-react-hooks@1.6.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
   integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
 
-eslint-plugin-react@7.12.4:
-  version "7.12.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"
-  integrity sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==
-  dependencies:
-    array-includes "^3.0.3"
-    doctrine "^2.1.0"
-    has "^1.0.3"
-    jsx-ast-utils "^2.0.1"
-    object.fromentries "^2.0.0"
-    prop-types "^15.6.2"
-    resolve "^1.9.0"
-
-eslint-plugin-unicorn@8.0.1:
+eslint-plugin-unicorn@8.0.1, eslint-plugin-unicorn@^8.0.0:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-8.0.1.tgz#9212c4d8dd729785db846db920148ca97d545696"
   integrity sha512-BIkPbCww71GZPnT1U4jzlNQyabmV7JlHu3qhCGLkZZKFp7jWkWdCQziadYdpLFLD5A+Z2nSi1LPe8/fkesvPVg==


### PR DESCRIPTION
https://ornikar.atlassian.net/browse/ONK-3265

Configs & plugins deviennent des dependencies + update des readme

Pour `eslint-config`, j'ai retiré les devDeps/Deps suivantes, car elles me semblent superflue : 

- `eslint-config-react`
- `eslint-plugin-node`

