### PR TITLE
feat: explicit-member-accessibility to no-public [no issue]

### DIFF
--- a/@ornikar/eslint-config-typescript/index.js
+++ b/@ornikar/eslint-config-typescript/index.js
@@ -49,8 +49,9 @@ module.exports = {
     '@typescript-eslint/no-empty-interface': 'off',
 
     /* changed rules */
-
-    // default is error, changed to warn
-    '@typescript-eslint/explicit-member-accessibility': 'warn',
+    
+    // https://github.com/typescript-eslint/typescript-eslint/issues/201
+    // private is comming in js world and no-public will be the most common way to read a js file (and probably ts)
+    '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
   },
 };


### PR DESCRIPTION
https://github.com/typescript-eslint/typescript-eslint/issues/201

private is comming in js world and no-public will be the most common way to read a js file (and probably ts too)

BREAKING CHANGE: typescript-eslint/explicit-member-accessibility rule changed