### PR TITLE
feat: ignore decorators in snapshots [no issue]

### DIFF
--- a/@ornikar/eslint-config-react/index.js
+++ b/@ornikar/eslint-config-react/index.js
@@ -31,6 +31,6 @@ module.exports = {
     'react/jsx-filename-extension': ['error', { extensions: ['js'] }],
 
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'error'
+    'react-hooks/exhaustive-deps': 'error',
   },
 };

--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -2,7 +2,9 @@
 
 'use strict';
 
+const React = require('react');
 const { shallow } = require('enzyme');
+const { shallowToJson } = require('enzyme-to-json');
 
 const decorateStory = (storyFn, decorators) =>
   decorators.reduce(
@@ -31,22 +33,73 @@ const decorateStory = (storyFn, decorators) =>
 // Mocked version of `import { action } from '@storybook/react'`.
 exports.action = actionName => jest.fn();
 
+const shallowOptions = {
+  disableLifecycleMethods: true,
+};
+
+const JestStoryWrapper = ({ children }) => children;
+const jestWrapperDecorator = storyFn =>
+  React.createElement(JestStoryWrapper, {}, storyFn());
+
 // Mocked version of: `import { storiesOf } from '@storybook/react'`
 exports.storiesOf = groupName => {
   const localDecorators = [];
+  const localParameters = {};
+
   // Mocked API to generate tests from & snapshot stories.
   const api = {
-    add(storyName, story) {
+    add(storyName, story, storyParameters = {}) {
+      const parameters = Object.assign({}, localParameters, storyParameters);
+      const { jest } = parameters;
+      const { componentToTest, ignore } = jest || {};
+
+      if (ignore) return api;
+
       describe(groupName, () => {
         it(storyName, () => {
-          expect(
-            shallow(decorateStory(story, localDecorators)(), {
-              disableLifecycleMethods: true,
-            })
-          ).toMatchSnapshot();
+          if (localDecorators.length === 0 && !componentToTest) {
+            expect(
+              shallowToJson(shallow(story(parameters), shallowOptions))
+            ).toMatchSnapshot();
+            return;
+          }
+
+          const wrapper = shallow(
+            decorateStory(
+              story,
+              componentToTest
+                ? localDecorators
+                : [jestWrapperDecorator, ...localDecorators]
+            )(parameters),
+            shallowOptions
+          );
+
+          if (componentToTest) {
+            const component = wrapper.find(componentToTest);
+            component.forEach(child => {
+              expect(shallowToJson(child.dive())).toMatchSnapshot();
+            });
+          } else {
+            let belowWrapper = true;
+            const toJsonMap = json => {
+              if (!belowWrapper) return { ...json, props: {} };
+              if (json.type === 'JestStoryWrapper') {
+                belowWrapper = false;
+              }
+              return json;
+            };
+            expect(
+              shallowToJson(wrapper, { map: toJsonMap })
+            ).toMatchSnapshot();
+          }
         });
       });
 
+      return api;
+    },
+
+    addParameters(parameters) {
+      Object.assign(localParameters, parameters);
       return api;
     },
 

--- a/@ornikar/jest-config-react/package.json
+++ b/@ornikar/jest-config-react/package.json
@@ -21,5 +21,8 @@
     "enzyme-adapter-react-16": "1.12.1",
     "enzyme-to-json": "3.3.5",
     "identity-obj-proxy": "3.0.0"
+  },
+  "devDependencies": {
+    "react": "16.8.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5900,6 +5900,16 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.6.3"
     scheduler "^0.11.2"
 
+react@16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
+  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.6"
+
 read-cmd-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz#2d5d157786a37c055d22077c32c53f8329e91c7b"
@@ -6338,6 +6348,14 @@ scheduler@^0.11.2:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.2.tgz#a8db5399d06eba5abac51b705b7151d2319d33d3"
   integrity sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.13.6:
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
+  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
En pratique, on peut aujourdhui pas les ignorer, car sela revient à ne pas les utiliser. Par contre, je cache leurs props.

https://github.com/airbnb/enzyme/issues/2103

J'ai également rajouté une option `ignore` et `componentToTest`, qui permet d'avoir des snapshots des composants et non des stories