### PR TITLE
feat: clean comments [no issue]

### DIFF
--- a/@ornikar/eslint-config/rules/best-practices.js
+++ b/@ornikar/eslint-config/rules/best-practices.js
@@ -4,5 +4,8 @@ module.exports = {
   rules: {
     // https://eslint.org/docs/rules/require-await
     'require-await': 'error',
+
+    // https://eslint.org/docs/2.0.0/rules/no-warning-comments
+    'no-warning-comments': 'error',
   },
 };

--- a/@ornikar/eslint-config/rules/best-practices.js
+++ b/@ornikar/eslint-config/rules/best-practices.js
@@ -6,6 +6,6 @@ module.exports = {
     'require-await': 'error',
 
     // https://eslint.org/docs/2.0.0/rules/no-warning-comments
-    'no-warning-comments': 'error',
+    'no-warning-comments': ['error', { "terms": ["todo", "fixme", "xxx", "console."], "location": "start" }],
   },
 };

--- a/@ornikar/stylelint-config/index.js
+++ b/@ornikar/stylelint-config/index.js
@@ -14,5 +14,8 @@ module.exports = {
     'no-descending-specificity': null,
 
     'order/order': ['declarations', 'rules', 'at-rules'],
+
+    // https://stylelint.io/user-guide/rules/comment-word-blacklist/
+    'comment-word-blacklist': ['console.log'],
   },
 };

--- a/@ornikar/stylelint-config/index.js
+++ b/@ornikar/stylelint-config/index.js
@@ -16,6 +16,6 @@ module.exports = {
     'order/order': ['declarations', 'rules', 'at-rules'],
 
     // https://stylelint.io/user-guide/rules/comment-word-blacklist/
-    'comment-word-blacklist': ['console.log'],
+    'comment-word-blacklist': ['/^TODO:/', '/^FIXME:/'],
   },
 };


### PR DESCRIPTION
Adds 2 small rules regarding code comments:

- **eslint**: `no-warning-comments`: no more `todo`, `fixme` or `xxx` in commlent (at the beginning)
- **stylelint**: `comment-word-blacklist`: no more `todo`, `fixme`


Motivations:
> - if this is to fix/todo, just fix or do before pushing on production :)
> - don't foget anything todo/tofix before pushing in production
> - nice extension for VSCode users: [todo-tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree) to have a good overview of your remaining TODO in your code
