### PR TITLE
fix: remove masterIssueApproval option [no issue]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,3 @@
 {
-  "extends": [
-    "config:js-lib",
-    "@ornikar",
-    ":masterIssue",
-    ":masterIssueApproval"
-  ]
+  "extends": ["config:js-lib", "@ornikar", ":masterIssue"]
 }


### PR DESCRIPTION
### Context

Les PR ne sont plus ouvertes automatiquement le lundi, car elles doivent être auparavant approve dans la master issue. Je pense qu'il vaut mieux désactiver cette option.

Cf la [doc](https://github.com/renovatebot/renovate/blob/956445eee424e12cf1ab80c160137ea6fd620dcb/website/docs/configuration-options.md#masterissueapproval) qui a enfin été mis à jour ^^

### Solution

Desactiver l'option masterIssueApproval


<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
