### PR TITLE
feat: support addon knobs [no issue]

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/addon-knobs.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/addon-knobs.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const decorator = getStory => getStory();
+
+exports.withKnobs = (...args) => {
+  // Used without options as .addDecorator(decorator)
+  if (typeof args[0] === 'function') {
+    return decorator(args[0]);
+  }
+
+  return (...innerArgs) => {
+    return decorator(innerArgs[0]);
+  };
+};
+
+exports.text = (name, value) => value;
+exports.boolean = (name, value) => value;
+exports.number = (name, value) => value;
+exports.color = (name, value) => value;
+exports.object = (name, value) => value;
+exports.select = (name, options, value) => value;
+exports.radios = (name, options, value) => value;
+exports.array = (name, value) => value;
+exports.date = (name, value) => value;
+exports.button = (name, callback) => callback;
+exports.files = (name, accept, value) => value;
+exports.optionsKnob = (name, valuesObj, value, optionsObj) => value;

--- a/@ornikar/jest-config-react/jest-preset.js
+++ b/@ornikar/jest-config-react/jest-preset.js
@@ -21,5 +21,8 @@ module.exports = {
   moduleNameMapper: {
     '\\.css$': 'identity-obj-proxy',
     '@storybook/react$': require.resolve('./__mocks__/@storybook/react'),
+    '@storybook/addon-knobs': require.resolve(
+      './__mocks__/@storybook/addon-knobs'
+    ),
   },
 };


### PR DESCRIPTION
### Context

Pour learner-app, on utilise beacoup les knobs dans les stories ce qui fait planter les snapshots lorsqu'on met a jour la config jest

### Solution

Implémentation du mock

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
