### PR TITLE
feat: add option to ignore all decorators [no issue]

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -51,13 +51,16 @@ exports.storiesOf = groupName => {
     add(storyName, story, storyParameters = {}) {
       const parameters = Object.assign({}, localParameters, storyParameters);
       const { jest } = parameters;
-      const { componentToTest, ignore } = jest || {};
+      const { componentToTest, ignore, ignoreDecorators } = jest || {};
 
       if (ignore) return api;
 
       describe(groupName, () => {
         it(storyName, () => {
-          if (localDecorators.length === 0 && !componentToTest) {
+          if (
+            (localDecorators.length === 0 || ignoreDecorators) &&
+            !componentToTest
+          ) {
             expect(
               shallowToJson(shallow(story(parameters), shallowOptions))
             ).toMatchSnapshot();
@@ -65,12 +68,14 @@ exports.storiesOf = groupName => {
           }
 
           const wrapper = shallow(
-            decorateStory(
-              story,
-              componentToTest
-                ? localDecorators
-                : [jestWrapperDecorator, ...localDecorators]
-            )(parameters),
+            ignoreDecorators
+              ? story(parameters)
+              : decorateStory(
+                  story,
+                  componentToTest
+                    ? localDecorators
+                    : [jestWrapperDecorator, ...localDecorators]
+                )(parameters),
             shallowOptions
           );
 


### PR DESCRIPTION
### Context

L'application des decorateurs rend les snapshots inutilisables, a cause du shallow. Permet également d'ignorer lorsqu'il n'y a que des decorateurs de layout.

### Solution

Ajoute une option qui ignore les decorateurs pour les stories qui n'en ont pas besoin en attendant un fix par enzyme

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
