### PR TITLE
chore: remove redundant masterissue config [no issue]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["config:js-lib", "@ornikar", ":masterIssue"]
+  "extends": ["config:js-lib", "@ornikar"]
 }


### PR DESCRIPTION
### Context

Option activé dans notre preset (publié). Il n'est plus nécessaire de l'activer manuellement sur le repo.

### Solution

Retirer le preset :masterIssue du renovate.json, car configuré par notre preset interne.

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
