### PR TITLE
fix: shallow snapshots with decorators [no issue]

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -85,16 +85,13 @@ exports.storiesOf = groupName => {
               expect(shallowToJson(child.dive())).toMatchSnapshot();
             });
           } else {
-            let belowWrapper = true;
-            const toJsonMap = json => {
-              if (!belowWrapper) return { ...json, props: {} };
-              if (json.type === 'JestStoryWrapper') {
-                belowWrapper = false;
-              }
-              return json;
-            };
             expect(
-              shallowToJson(wrapper, { map: toJsonMap })
+              shallowToJson(
+                wrapper
+                  .find(JestStoryWrapper)
+                  .children()
+                  .shallow()
+              )
             ).toMatchSnapshot();
           }
         });


### PR DESCRIPTION
### Context

https://github.com/airbnb/enzyme/pull/1966 a été mergée et dispo depuis les derniers plateform days

Les snapshots ont maintenant une utilitée !

Exemple: 

  ● sections/Instructor/CommentsDrawer/Comment › No Author


```diff
- Snapshot
+ Received

- <div>
-   <ContextProvider>
-     <MockResults>
-       <JestStoryWrapper>
-         <Comment
-           comment={
-             CommentResource {
-               "author": null,
-               "comment": "Contenu du commentaire.",
-               "created_at": "2014-12-17 17:11:29",
-               "id": 4,
-               "updated_at": "2014-12-17 17:11:29",
-               Symbol(Defined Members): Array [
-                 "id",
-                 "comment",
-                 "created_at",
-                 "updated_at",
-                 "author",
-               ],
-             }
-           }
-         />
-       </JestStoryWrapper>
-     </MockResults>
-   </ContextProvider>
- </div>
+ <Comment
+   author={
+     <Text
+       strong={true}
+     >
+       MS
+     </Text>
+   }
+   avatar={<UserAvatar />}
+   className="Comment"
+   content="Contenu du commentaire."
+   datetime={
+     <FormattedDate
+       day="2-digit"
+       month="numeric"
+       value="2014-12-17 17:11:29"
+       year="numeric"
+     />
+   }
+ />
```




<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
