### PR TITLE
feat: enable import/no-anonymous-default-export for functions [no issue]

### DIFF
--- a/@ornikar/eslint-config-babel-use/index.js
+++ b/@ornikar/eslint-config-babel-use/index.js
@@ -22,5 +22,24 @@ module.exports = {
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/import/no-extraneous-dependencies.md
     // override default airbnb exceptions
     'import/no-extraneous-dependencies': ['error', { devDependencies: false }],
+
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-anonymous-default-export.md
+    // Empeche de créer des composants et de les exporter sans les nommer.
+    // Exemple: `export default () => { return <Logo color="black" />; };`
+    // Ce qu'il faut faire: `export default function BlackLogo() { return <Logo color="black" /> };`
+    // Lorsque des componsants n'ont pas de noms, react nous envoie des erreurs avec une stack pas explicite.
+    // Les noms disparaissent lors de la minification du bundle, lorsqu'il ne sont pas utilisés et que ce sont des default.
+    'import/no-anonymous-default-export': [
+      'error',
+      {
+        allowArray: true,
+        allowArrowFunction: false,
+        allowAnonymousClass: false,
+        allowAnonymousFunction: false,
+        allowCallExpression: true,
+        allowLiteral: true,
+        allowObject: true,
+      },
+    ],
   },
 };


### PR DESCRIPTION
### Context

Ne pas nommer un composant react rend le debug plus compliqué car ils apparaitront comme anonymes dans les stacktrace react.

### Solution

Cette règle eslint force à nommer toutes les fonctions exportés. Cela concerne donc une majorité des composants (certains ne sont pas exportés) et une majorité des fonctions (certaines ne sont pas des composants react, mais c'est pas plus mal de les nommer aussi pour les stacks js)