### PR TITLE
fix: disable prefer-event-key rule [no issue]

### DIFF
--- a/@ornikar/eslint-config/plugins/unicorn.js
+++ b/@ornikar/eslint-config/plugins/unicorn.js
@@ -46,7 +46,7 @@ module.exports = {
     'unicorn/prefer-type-error': 'error',
 
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-event-key.md
-    'unicorn/prefer-event-key': 'error',
+    'unicorn/prefer-event-key': 'off',
 
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-flat-map.md
     'unicorn/prefer-flat-map': 'error',


### PR DESCRIPTION
### Context

Désactivation de la règle `prefer-event-key`
Certains navigateurs ne supportent pas encore l'attribut `key`

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
