### PR TITLE
fix: add storyname to parameters [no issue]

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -45,7 +45,7 @@ exports.storiesOf = (groupName) => {
   // Mocked API to generate tests from & snapshot stories.
   const api = {
     add(storyName, story, storyParameters = {}) {
-      const parameters = Object.assign({}, localParameters, storyParameters);
+      const parameters = Object.assign({ name: storyName }, localParameters, storyParameters);
       const { jest } = parameters;
       const { componentToTest, ignore, ignoreDecorators } = jest || {};
 


### PR DESCRIPTION
### Context

Ajout de la propriété name aux paramètres passés par notre mock de @storybook/react.
Permettra d'éviter une erreur jest dans Kitt.


<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
