### PR TITLE
feat: ban typescript Omit type [no issue]

### DIFF
--- a/@ornikar/eslint-config-typescript/index.js
+++ b/@ornikar/eslint-config-typescript/index.js
@@ -44,5 +44,15 @@ module.exports = {
     // https://github.com/typescript-eslint/typescript-eslint/issues/201
     // private is comming in js world and no-public will be the most common way to read a js file (and probably ts)
     '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
+
+    '@typescript-eslint/ban-types': [
+      'error',
+      {
+        types: {
+          Omit:
+            'Prefer `Except` from type-fest. https://github.com/sindresorhus/type-fest/blob/master/source/except.d.ts',
+        },
+      },
+    ],
   },
 };


### PR DESCRIPTION
### Context

La version d'Omit inclue dans typescript n'est pas stricte. Voir issue https://github.com/microsoft/TypeScript/issues/30825

### Solution

Eslint permet de bannir ce type: https://github.com/microsoft/TypeScript/issues/30825#issuecomment-508584855

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [x] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
