### PR TITLE
feat: disable prop types rule in eslint ts config [no issue]

### DIFF
--- a/@ornikar/eslint-config-typescript-react/index.js
+++ b/@ornikar/eslint-config-typescript-react/index.js
@@ -22,5 +22,6 @@ module.exports = {
       },
     ],
     'react/jsx-filename-extension': ['error', { extensions: ['tsx', 'js'] }],
+    'react/prop-types': 'off',
   },
 };


### PR DESCRIPTION
### Context

Plus besoin d'utiliser les propTypes quand on utilise typescript

### Solution

Désactivation de la règle react/prop-types dans la configuration eslint Typescript x React

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
