### PR TITLE
feat: add explicit function return type rule [no issue]

### DIFF
--- a/@ornikar/eslint-config-typescript/index.js
+++ b/@ornikar/eslint-config-typescript/index.js
@@ -39,6 +39,10 @@ module.exports = {
     // for example props can extends other props without setting new ones
     '@typescript-eslint/no-empty-interface': 'off',
 
+    // type annotations are allowed on the variable of a function expression rather than on the function directly
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md#allowtypedfunctionexpressions
+    '@typescript-eslint/explicit-function-return-type': ['error', { allowTypedFunctionExpressions: true }],
+
     /* changed rules */
 
     // https://github.com/typescript-eslint/typescript-eslint/issues/201


### PR DESCRIPTION
### Context

Pour pouvoir typer la déclaration d'une fonction et ne pas avoir à typer en plus le retour de cette fonction
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md#allowtypedfunctionexpressions

### Solution

Ajout de la règle `explicit-function-return-type` avec l'option `allowTypedFunctionExpressions`
<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
