### PR TITLE
feat: support lerna in jest configs ONK-3913

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -68,6 +68,10 @@ exports.storiesOf = (groupName) => {
       return api;
     },
 
+    addWithPercyOptions(storyName, percyOptions, story) {
+      api.add(storyName, story);
+    },
+
     addParameters(parameters) {
       Object.assign(localParameters, parameters);
       return api;

--- a/@ornikar/jest-config-react/jest-preset.js
+++ b/@ornikar/jest-config-react/jest-preset.js
@@ -1,14 +1,10 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
 const baseJestPreset = require('@ornikar/jest-config/jest-preset');
-
-const useTypescript = fs.existsSync(path.resolve('tsconfig.json'));
 
 module.exports = {
   ...baseJestPreset,
-  testMatch: [...baseJestPreset.testMatch, `<rootDir>/src/**/stories.${useTypescript ? '{js,tsx}' : 'js'}`],
+  testMatch: [...baseJestPreset.testMatch, baseJestPreset.testMatch[0].replace('**/__tests__/**/*.', '**/stories.')],
   snapshotSerializers: ['enzyme-to-json/serializer'],
   setupFiles: [
     ...baseJestPreset.setupFiles.slice(0, -1),

--- a/@ornikar/jest-config-react/package.json
+++ b/@ornikar/jest-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ornikar/jest-config-react",
-  "version": "1.10.2",
+  "version": "2.2.0",
   "description": "jest config",
   "repository": "ornikar/shared-configs",
   "main": "jest-preset.js",

--- a/@ornikar/jest-config-react/package.json
+++ b/@ornikar/jest-config-react/package.json
@@ -17,10 +17,10 @@
   },
   "dependencies": {
     "@ornikar/jest-config": "^2.2.0",
-    "enzyme": "3.10.0",
-    "enzyme-adapter-react-16": "1.14.0",
-    "enzyme-to-json": "3.3.5",
-    "identity-obj-proxy": "3.0.0"
+    "enzyme": "^3.10.0",
+    "enzyme-adapter-react-16": "^1.14.0",
+    "enzyme-to-json": "^3.3.5",
+    "identity-obj-proxy": "^3.0.0"
   },
   "devDependencies": {
     "react": "16.8.6"

--- a/@ornikar/jest-config/jest-preset.js
+++ b/@ornikar/jest-config/jest-preset.js
@@ -3,14 +3,24 @@
 const fs = require('fs');
 const path = require('path');
 
+const useLerna = fs.existsSync(path.resolve('lerna.json'));
 const useTypescript = fs.existsSync(path.resolve('tsconfig.json'));
+const pkg = JSON.parse(fs.readFileSync(path.resolve('package.json')));
+
+const src = (() => {
+  if (!useLerna) return 'src';
+  if (pkg.workspaces.length === 1) return `${pkg.workspaces[0]}/src`;
+  return `{${pkg.workspaces.join(',')}}/src`;
+})();
 
 module.exports = {
   cacheDirectory: './node_modules/.cache/jest',
   testMatch: [
-    `<rootDir>/src/**/__tests__/**/*.${useTypescript ? '{js,ts,tsx}' : 'js'}`,
-    `<rootDir>/src/**/*.test.${useTypescript ? '{js,ts,tsx}' : 'js'}`,
+    // This first testMatch is used in jest-config-react
+    `<rootDir>/${src}/**/__tests__/**/*.${useTypescript ? '{js,ts,tsx}' : 'js'}`,
+    `<rootDir>/${src}/**/*.test.${useTypescript ? '{js,ts,tsx}' : 'js'}`,
   ],
+  testPathIgnorePatterns: [],
   setupFilesAfterEnv: [require.resolve('./test-setup-after-env.js')],
   setupFiles: [
     require.resolve('./test-shim.js'),


### PR DESCRIPTION
Use presence of lerna.json to detect a lerna repo.
Also remove detections in jest-config-react and use a replace string method instead
Also add support for `addWithPercyOptions`, used in components

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Infos:
[JIRA issue: ONK-3913](https://ornikar.atlassian.net/browse/ONK-3913)
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [x] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
