### PR TITLE
fix: dont use postCss plugin in node builds, css is not imported [no issue]

### DIFF
--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -46,20 +46,20 @@ const createBuildsForPackage = (packagesDir, packageName) => {
       external: target === 'node' ? (filePath) => (filePath.endsWith('.css') ? false : external(filePath)) : external,
 
       plugins: [
-        target !== 'browser' &&
-          ignoreImport({
-            extensions: browserOnlyExtensions,
-          }),
-        postcss({
-          extract: exportCss ? `${distPath}/styles.css` : true,
-          modules: true,
-          config: exportCss
-            ? {
-                path: path.resolve('./config/rollup-postcss.config'),
-              }
-            : false,
-          minimize: false,
-        }),
+        target === 'browser'
+          ? postcss({
+              extract: exportCss ? `${distPath}/styles.css` : true,
+              modules: true,
+              config: exportCss
+                ? {
+                    path: path.resolve('./config/rollup-postcss.config'),
+                  }
+                : false,
+              minimize: false,
+            })
+          : ignoreImport({
+              extensions: browserOnlyExtensions,
+            }),
         babel({
           babelrc: false,
           configFile: true,


### PR DESCRIPTION
### Context

On this [PR](https://github.com/ornikar/components/pull/329) => the node builds fail when parsing css files.

I'm not exactly sure why, but if you ignore .css imports in node builds, the postCSSPlugin plugin still runs on those files & crashes.

### Solution

**Node builds** => Ignore css & no postCSSPlugin
**Browser builds** => Use postCSSPlugin

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
