### PR TITLE
fix: remove rollup plugin ignore import dep & usage [no issue]

### DIFF
--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -6,14 +6,12 @@ const postcss = require('rollup-plugin-postcss');
 const babel = require('rollup-plugin-babel');
 const resolve = require('rollup-plugin-node-resolve');
 const commonjs = require('rollup-plugin-commonjs');
-const ignoreImport = require('rollup-plugin-ignore-import');
 const configExternalDependencies = require('rollup-config-external-dependencies');
 
 // eslint-disable-next-line import/no-dynamic-require
 const rootPkg = require(path.resolve('./package.json'));
 
 const extensions = ['.js', '.jsx', '.tsx', '.ts'];
-const browserOnlyExtensions = ['.css'];
 
 const createBuildsForPackage = (packagesDir, packageName) => {
   // eslint-disable-next-line import/no-dynamic-require, global-require
@@ -46,20 +44,16 @@ const createBuildsForPackage = (packagesDir, packageName) => {
       external: target === 'node' ? (filePath) => (filePath.endsWith('.css') ? false : external(filePath)) : external,
 
       plugins: [
-        target === 'browser'
-          ? postcss({
-              extract: exportCss ? `${distPath}/styles.css` : true,
-              modules: true,
-              config: exportCss
-                ? {
-                    path: path.resolve('./config/rollup-postcss.config'),
-                  }
-                : false,
-              minimize: false,
-            })
-          : ignoreImport({
-              extensions: browserOnlyExtensions,
-            }),
+        postcss({
+          extract: exportCss ? `${distPath}/styles.css` : true,
+          modules: true,
+          config: exportCss
+            ? {
+                path: path.resolve('./config/rollup-postcss.config'),
+              }
+            : false,
+          minimize: false,
+        }),
         babel({
           babelrc: false,
           configFile: true,

--- a/@ornikar/rollup-config/package.json
+++ b/@ornikar/rollup-config/package.json
@@ -21,7 +21,6 @@
     "rollup-config-external-dependencies": "^1.0.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.1",
-    "rollup-plugin-ignore-import": "^1.1.2",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-postcss": "^2.0.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9187,11 +9187,6 @@ rollup-plugin-commonjs@^10.0.1:
     resolve "^1.11.0"
     rollup-pluginutils "^2.8.1"
 
-rollup-plugin-ignore-import@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-ignore-import/-/rollup-plugin-ignore-import-1.1.2.tgz#be8e0ba6cae6d38f9579fc32b0ae9ccf38ba7fb0"
-  integrity sha512-rqRCfJl86XYplAVBgInwLLmpzp9OBA/7xLp3WydrqmtsNW9ZsrzMUOQTFQV5FsLl2rGiSE1R6nFsA1ymzDvRoQ==
-
 rollup-plugin-node-resolve@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"


### PR DESCRIPTION
### Context

It doesn't work, or i can't make it work 😕 

### Solution

Remove usage of this plugin in rollup config.

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
