### PR TITLE
fix: add remove-proptype babel plugin [no issue]

### DIFF
--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint-disable complexity */
+
 const path = require('path');
 const fs = require('fs');
 const postcss = require('rollup-plugin-postcss');
@@ -96,6 +98,12 @@ const createBuildsForPackage = (packagesDir, packageName) => {
                     },
                   },
                 ],
+              },
+            ],
+            production && [
+              require.resolve('babel-plugin-transform-react-remove-prop-types'),
+              {
+                removeImport: true,
               },
             ],
             require.resolve('babel-plugin-minify-dead-code-elimination'),

--- a/@ornikar/rollup-config/package.json
+++ b/@ornikar/rollup-config/package.json
@@ -18,6 +18,7 @@
     "babel-plugin-discard-module-references": "^1.1.2",
     "babel-plugin-minify-dead-code-elimination": "^0.5.0",
     "babel-plugin-minify-replace": "^0.5.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "rollup-config-external-dependencies": "^1.0.0",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-commonjs": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2215,6 +2215,11 @@ babel-plugin-syntax-jsx@^6.18.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
+babel-plugin-transform-react-remove-prop-types@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
+  integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
+
 babel-polyfill@6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"


### PR DESCRIPTION
### Context

Proptypes aren't removed from built files

See : https://circleci.com/gh/ornikar/components/7822?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

### Solution

Add a babel plugin that removes proptypes from built files 

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
