### PR TITLE
fix: detect presence of prettier or stylelint in project devdeps [no issue]

### DIFF
--- a/@ornikar/repo-config/createLintStagedConfig.js
+++ b/@ornikar/repo-config/createLintStagedConfig.js
@@ -12,19 +12,21 @@ const getSrcDirectories = (srcDirectoryName = 'src') =>
 module.exports = function createLintStagedConfig(options = {}) {
   const srcExtensions = options.srcExtensions || ['js'];
   const srcDirectories = getSrcDirectories(options.srcDirectoryName);
-
+  const hasPrettier = pkg.devDependencies && pkg.devDependencies.prettier;
+  const hasStyleLint = pkg.devDependencies && pkg.devDependencies.stylelint;
+  const jsonFiles = `{.eslintrc.json,package.json${
+    workspaces
+      ? `,${workspaces.map((workspacePath) => `${workspacePath}/{.eslintrc.json,package.json}`).join(',')}`
+      : ''
+  }`;
   return {
     'yarn.lock': ['yarn-update-lock', 'git add'],
-    [`{.eslintrc.json,package.json${
-      workspaces
-        ? `,${workspaces.map((workspacePath) => `${workspacePath}/{.eslintrc.json,package.json}`).join(',')}`
-        : ''
-    }`]: ['prettier --parser json --write', 'git add'],
+    [jsonFiles]: [hasPrettier && 'prettier --parser json --write', 'git add'].filter(Boolean),
     [`{.storybook,${srcDirectories}}/**/*.css`]: [
-      'prettier --parser css --write',
-      'stylelint --quiet --fix',
+      hasPrettier && 'prettier --parser css --write',
+      hasStyleLint && 'stylelint --quiet --fix',
       'git add',
-    ],
+    ].filter(Boolean),
 
     [`${srcDirectories}/**/*.{${srcExtensions.join(',')}}`]: ['eslint --fix --quiet', 'git add'],
     '{scripts,config,.storyboook}/*.js': ['eslint --fix --quiet', 'git add'],


### PR DESCRIPTION
conditionnally apply lint staged commands depending on presence of node modules

It allows us to use lint-staged & husky inside projects without prettier or stylelint or both (such as michel)

### Context

Explain here why this PR is needed

### Solution

If needed, explain here the solution you chose for this

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
