### PR TITLE
fix(renovate-config): group react and react types packages [no issue]

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -64,15 +64,6 @@
           ]
         },
         {
-          "groupName": "react",
-          "packageNames": [
-            "react",
-            "react-dom",
-            "@types/react",
-            "@types/react-dom",
-          ]
-        },
-        {
           "groupName": "babel community packages",
           "excludePackageNames": [
             "babel-eslint"
@@ -86,6 +77,15 @@
           "packagePatterns": [
             "^rollup"
           ]
+        },
+        {
+          "groupName": "react",
+          "packageNames": [
+            "react",
+            "react-dom",
+            "@types/react",
+            "@types/react-dom",
+          ],
         },
         {
           "packageNames": [

--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -64,6 +64,15 @@
           ]
         },
         {
+          "groupName": "react",
+          "packageNames": [
+            "react",
+            "react-dom",
+            "@types/react",
+            "@types/react-dom",
+          ]
+        },
+        {
           "groupName": "babel community packages",
           "excludePackageNames": [
             "babel-eslint"

--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -84,8 +84,8 @@
             "react",
             "react-dom",
             "@types/react",
-            "@types/react-dom",
-          ],
+            "@types/react-dom"
+          ]
         },
         {
           "packageNames": [

--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -80,9 +80,12 @@
         },
         {
           "groupName": "react",
+          "description": "react monorepo",
+          "sourceUrlPrefixes": [
+            "https://github.com/facebook/react"
+          ],
           "packageNames": [
-            "react",
-            "react-dom",
+            "@hot-loader/react-dom",
             "@types/react",
             "@types/react-dom"
           ]


### PR DESCRIPTION
### Context

Packages `react`, `react-dom` and their types should be updated at the same time

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [x] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
