### PR TITLE
fix(renovate-config): only patch should be merged automaticly for @types [no issue]

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -88,12 +88,27 @@
           ],
           "packagePatterns": [
             "^@commitlint",
-            "^eslint",
-            "^@types"
+            "^eslint"
           ],
           "updateTypes": [
             "patch",
             "minor"
+          ],
+          "labels": [
+            ":ok_hand: code/approved",
+            ":soon: automerge"
+          ],
+          "masterIssueApproval": false,
+          "schedule": [
+            "before 5:00am"
+          ]
+        },
+        {
+          "packagePatterns": [
+            "^@types"
+          ],
+          "updateTypes": [
+            "patch"
           ],
           "labels": [
             ":ok_hand: code/approved",


### PR DESCRIPTION
### Context

minor generally is the same as the lib ? so it should be synced to the package installed, not auto merged (for example we should not install @types/react@16.9 unless we also have react 16.9)

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [x] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
