### PR TITLE
fix: run yarn-update-lock on package.json changes [no issue]

### DIFF
--- a/@ornikar/repo-config/createLintStagedConfig.js
+++ b/@ornikar/repo-config/createLintStagedConfig.js
@@ -14,7 +14,11 @@ module.exports = function createLintStagedConfig(options = {}) {
   const srcDirectories = getSrcDirectories(options.srcDirectoryName);
 
   return {
-    'yarn.lock': ['yarn-update-lock', 'git add'],
+    [`{yarn.lock,package.json${
+      workspaces
+        ? `,${workspaces.map((workspacePath) => `${workspacePath}/package.json`).join(',')}`
+        : ''
+    }}`]: (filenames) => ['yarn-update-lock', 'git add'],
     [`{.eslintrc.json,package.json${
       workspaces
         ? `,${workspaces.map((workspacePath) => `${workspacePath}/{.eslintrc.json,package.json}`).join(',')}`

--- a/@ornikar/repo-config/createLintStagedConfig.js
+++ b/@ornikar/repo-config/createLintStagedConfig.js
@@ -18,7 +18,7 @@ module.exports = function createLintStagedConfig(options = {}) {
       workspaces
         ? `,${workspaces.map((workspacePath) => `${workspacePath}/package.json`).join(',')}`
         : ''
-    }}`]: (filenames) => ['yarn-update-lock', 'git add'],
+    }}`]: (filenames) => ['yarn-update-lock', 'git add yarn.lock'],
     [`{.eslintrc.json,package.json${
       workspaces
         ? `,${workspaces.map((workspacePath) => `${workspacePath}/{.eslintrc.json,package.json}`).join(',')}`


### PR DESCRIPTION
We could not do this before because that would have mean yarn could run twice in the same time, but now we can use callbacks to make it run only once !

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [x] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
