### PR TITLE
fix: createLintStagedConfig missing } for json [no issue]

### DIFF
--- a/@ornikar/repo-config/createLintStagedConfig.js
+++ b/@ornikar/repo-config/createLintStagedConfig.js
@@ -19,7 +19,7 @@ module.exports = function createLintStagedConfig(options = {}) {
       workspaces
         ? `,${workspaces.map((workspacePath) => `${workspacePath}/{.eslintrc.json,package.json}`).join(',')}`
         : ''
-    }`]: ['prettier --parser json --write', 'git add'],
+    }}`]: ['prettier --parser json --write', 'git add'],
     [`{.storybook,${srcDirectories}}/**/*.css`]: [
       'prettier --parser css --write',
       'stylelint --quiet --fix',


### PR DESCRIPTION
`}` missing for json config files

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
