### PR TITLE
chore: execute typescript css linter if typescript exists in project

### DIFF
--- a/@ornikar/repo-config-react/createLintStagedConfig.js
+++ b/@ornikar/repo-config-react/createLintStagedConfig.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const path = require('path');
+const fs = require('fs');
 const createBaseLintStagedConfig = require('@ornikar/repo-config/createLintStagedConfig');
 
 // eslint-disable-next-line import/no-dynamic-require
-const pkg = require(path.resolve('package.json'));
+const pkg = JSON.stringify(fs.readFileSync(path.resolve('package.json'), 'utf-8'));
 
 module.exports = function createLintStagedConfig(options = {}) {
   const config = createBaseLintStagedConfig({ srcExtensions: ['js', 'ts', 'tsx'] });
@@ -12,17 +13,18 @@ module.exports = function createLintStagedConfig(options = {}) {
   // eslint-disable-next-line prefer-destructuring
   const srcDirectories = createBaseLintStagedConfig.getSrcDirectories();
 
-  const additionalConfig = {
+  Object.assign(config, {
     '*.svg': ['svgo --multipass --config=node_modules/@ornikar/repo-config-react/.svgo.yml', 'git add'],
-  };
-  if (pkg.devDependencies.typescript) {
-    additionalConfig[`${srcDirectories}/**/*.module.{css,css.d.ts}`] = (filenames) => [
-      "tcm -s -p '**/*.module.css'",
-      "git add '**/**.d.ts'",
-    ];
-  }
+  });
 
-  Object.assign(config, additionalConfig);
+  if (pkg.devDependencies.typescript) {
+    Object.assign(config, {
+      [`${srcDirectories}/**/*.module.{css,css.d.ts}`]: (filenames) => [
+        "tcm -s -p '**/*.module.css'",
+        "git add '**/**.d.ts'",
+      ],
+    });
+  }
 
   return config;
 };

--- a/@ornikar/repo-config-react/createLintStagedConfig.js
+++ b/@ornikar/repo-config-react/createLintStagedConfig.js
@@ -1,6 +1,10 @@
 'use strict';
 
+const path = require('path');
 const createBaseLintStagedConfig = require('@ornikar/repo-config/createLintStagedConfig');
+
+// eslint-disable-next-line import/no-dynamic-require
+const pkg = require(path.resolve('package.json'));
 
 module.exports = function createLintStagedConfig(options = {}) {
   const config = createBaseLintStagedConfig({ srcExtensions: ['js', 'ts', 'tsx'] });
@@ -8,13 +12,17 @@ module.exports = function createLintStagedConfig(options = {}) {
   // eslint-disable-next-line prefer-destructuring
   const srcDirectories = createBaseLintStagedConfig.getSrcDirectories();
 
-  Object.assign(config, {
-    [`${srcDirectories}/**/*.module.{css,css.d.ts}`]: (filenames) => [
+  const additionalConfig = {
+    '*.svg': ['svgo --multipass --config=node_modules/@ornikar/repo-config-react/.svgo.yml', 'git add'],
+  };
+  if (pkg.devDependencies.typescript) {
+    additionalConfig[`${srcDirectories}/**/*.module.{css,css.d.ts}`] = (filenames) => [
       "tcm -s -p '**/*.module.css'",
       "git add '**/**.d.ts'",
-    ],
-    '*.svg': ['svgo --multipass --config=node_modules/@ornikar/repo-config-react/.svgo.yml', 'git add'],
-  });
+    ];
+  }
+
+  Object.assign(config, additionalConfig);
 
   return config;
 };

--- a/@ornikar/repo-config-react/createLintStagedConfig.js
+++ b/@ornikar/repo-config-react/createLintStagedConfig.js
@@ -4,7 +4,6 @@ const path = require('path');
 const fs = require('fs');
 const createBaseLintStagedConfig = require('@ornikar/repo-config/createLintStagedConfig');
 
-// eslint-disable-next-line import/no-dynamic-require
 const pkg = JSON.stringify(fs.readFileSync(path.resolve('package.json'), 'utf-8'));
 
 module.exports = function createLintStagedConfig(options = {}) {


### PR DESCRIPTION
### Context

Sur les projet sans TypeScript, des fichiers .css.d.ts sont créés et ajoutés aux commits.

### Conclusion

Limiter l'exécution du linter css ts en fonction de la présence de TypeScript dans le projet. 

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
