### PR TITLE
fix: parse JSON file instead of stringifying it [no issue]

### DIFF
--- a/@ornikar/repo-config-react/createLintStagedConfig.js
+++ b/@ornikar/repo-config-react/createLintStagedConfig.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const createBaseLintStagedConfig = require('@ornikar/repo-config/createLintStagedConfig');
 
-const pkg = JSON.stringify(fs.readFileSync(path.resolve('package.json'), 'utf-8'));
+const pkg = JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf-8'));
 
 module.exports = function createLintStagedConfig(options = {}) {
   const config = createBaseLintStagedConfig({ srcExtensions: ['js', 'ts', 'tsx'] });


### PR DESCRIPTION
### Context

repo-config-react 1.0.1 does not work :)
It crashes when reading the properties of `pkg = JSON.stringify('...')`

### Solution

`package.json` should be parsed, not stringified.

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
