### PR TITLE
fix(jest-config-react): preset for non craco configs [no issue]

### DIFF
--- a/@ornikar/jest-config-react/jest-preset.js
+++ b/@ornikar/jest-config-react/jest-preset.js
@@ -1,6 +1,10 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const baseJestPreset = require('@ornikar/jest-config/jest-preset');
+
+const useCraco = fs.existsSync(path.resolve('craco.config.js'));
 
 module.exports = {
   ...baseJestPreset,
@@ -11,9 +15,15 @@ module.exports = {
     require.resolve('./test-setup'),
     baseJestPreset.setupFiles[baseJestPreset.setupFiles.length - 1],
   ],
-  transform: {
-    '\\.svg$': require.resolve('./fileTransform'),
-  },
+  transform: useCraco
+    ? {
+        '\\.svg$': require.resolve('./fileTransform'),
+      }
+    : {
+        '\\.svg$': require.resolve('./fileTransform'),
+        '^.+\\.(js|jsx|ts|tsx)$': '<rootDir>/node_modules/babel-jest',
+      },
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$', '^.+\\.css$'],
   moduleNameMapper: {
     '\\.css$': 'identity-obj-proxy',
     '@storybook/react$': require.resolve('./__mocks__/@storybook/react'),


### PR DESCRIPTION
### Context

En utilisant transform, on override la config de base de jest. Ca ne posait pas de soucis sur craco car cra reconfigure bien, par contre sur un projet non craco ca ne marchait pas (plus de transformation babel-jest)

### Solution

Configuration pour babel-jest
Testé sur kitt et components

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [x] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
