### PR TITLE
fix(rollup-config): load postcss config [no issue]

### DIFF
--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -13,6 +13,8 @@ const configExternalDependencies = require('rollup-config-external-dependencies'
 
 // eslint-disable-next-line import/no-dynamic-require
 const rootPkg = require(path.resolve('./package.json'));
+// eslint-disable-next-line import/no-dynamic-require
+const postcssConfig = require(path.resolve('./config/rollup-postcss.config.js'));
 
 const extensions = ['.js', '.jsx', '.tsx', '.ts'];
 const browserOnlyExtensions = ['.css'];
@@ -60,11 +62,8 @@ const createBuildsForPackage = (packagesDir, packageName) => {
           modules: {
             localIdentName: '[local]__[hash:base64:5]',
           },
-          config: exportCss
-            ? {
-                path: path.resolve('./config/rollup-postcss.config'),
-              }
-            : false,
+          config: false,
+          plugins: exportCss ? postcssConfig.plugins : false,
           minimize: false,
         }),
         babel({

--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* eslint-disable complexity */
+/* eslint-disable complexity, import/no-dynamic-require */
 
 const path = require('path');
 const fs = require('fs');
@@ -11,9 +11,7 @@ const commonjs = require('rollup-plugin-commonjs');
 const ignoreImport = require('rollup-plugin-ignore-import');
 const configExternalDependencies = require('rollup-config-external-dependencies');
 
-// eslint-disable-next-line import/no-dynamic-require
 const rootPkg = require(path.resolve('./package.json'));
-// eslint-disable-next-line import/no-dynamic-require
 const postcssConfig = require(path.resolve('./config/rollup-postcss.config.js'));
 
 const extensions = ['.js', '.jsx', '.tsx', '.ts'];


### PR DESCRIPTION
### Context

Les fichiers dist/styles.css dans les components ne sont aujourdhui pas compilés, depuis la branche typescript
Il semblerait que la config postcss n'est pas bien chargée. 

### Solution

Chargement de la config avec un require, et passage de plugins directement. Cela évite également de faire le calcul coté plugin postcss plusieurs fois (1 pour chaque package) :)

<!-- Uncomment this if you need a testing plan
<h3>Testing plan</h3>
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [x] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
