### PR TITLE
fix: package json lint-staged racing condition [no issue]

### DIFF
--- a/@ornikar/repo-config/createLintStagedConfig.js
+++ b/@ornikar/repo-config/createLintStagedConfig.js
@@ -16,11 +16,18 @@ module.exports = function createLintStagedConfig(options = {}) {
   return {
     [`{yarn.lock,package.json${
       workspaces ? `,${workspaces.map((workspacePath) => `${workspacePath}/package.json`).join(',')}` : ''
-    }}`]: (filenames) => ['yarn-update-lock', 'git add yarn.lock'],
-    [`{.eslintrc.json,package.json${
-      workspaces
-        ? `,${workspaces.map((workspacePath) => `${workspacePath}/{.eslintrc.json,package.json}`).join(',')}`
-        : ''
+    }}`]: (filenames) => {
+      const packagejsonFilenames = filenames.filter((filename) => filename.endsWith('.json'));
+      return [
+        'yarn-update-lock',
+        packagejsonFilenames.length === 0
+          ? undefined
+          : `prettier --parser json --write ${packagejsonFilenames.join(' ')}`,
+        `git add ${filenames.join(' ')}`,
+      ].filter(Boolean);
+    },
+    [`{.eslintrc.json${
+      workspaces ? `,${workspaces.map((workspacePath) => `${workspacePath}/{.eslintrc.json}`).join(',')}` : ''
     }}`]: ['prettier --parser json --write', 'git add'],
     [`{.storybook,${srcDirectories}}/**/*.css`]: [
       'prettier --parser css --write',


### PR DESCRIPTION
### Context

Because yarn and prettier both run at the same time, the resulted package.json could be formatted by either yarn or prettier depending on the PR

### Solution

The formatting of package.json is done after yarn-update-lock

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [x] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
