### PR TITLE
chore: remove yarn-update-lock and use yarn-deduplicate directly [no issue]

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -17,15 +17,11 @@
       "masterIssueApproval": true,
       "rebaseStalePrs": true,
       "updateNotScheduled": false,
-      "postUpdateOptions": [
-        "yarnDedupeHighest"
-      ],
+      "postUpdateOptions": ["yarnDedupeHighest"],
       "prBodyNotes": [
         "<!-- do not edit after this -->This will be auto filled by reviewflow.<!-- end - don't add anything after this -->"
       ],
-      "labels": [
-        ":soon: automerge"
-      ],
+      "labels": [":soon: automerge"],
       "packageRules": [
         {
           "groupName": "Shared Configs Ornikar",
@@ -50,9 +46,7 @@
             "@ornikar/webpack-config"
           ],
           "rebaseStalePrs": false,
-          "schedule": [
-            "at any time"
-          ]
+          "schedule": ["at any time"]
         },
         {
           "groupName": "Components Ornikar",
@@ -67,107 +61,52 @@
             "@ornikar/validators"
           ],
           "rebaseStalePrs": false,
-          "schedule": [
-            "at any time"
-          ]
+          "schedule": ["at any time"]
         },
         {
           "groupName": "eslint packages",
-          "packageNames": [
-            "babel-eslint"
-          ],
-          "packagePatterns": [
-            "^eslint"
-          ]
+          "packageNames": ["babel-eslint"],
+          "packagePatterns": ["^eslint"]
         },
         {
           "groupName": "babel community packages",
-          "excludePackageNames": [
-            "babel-eslint"
-          ],
-          "packagePatterns": [
-            "^babel"
-          ]
+          "excludePackageNames": ["babel-eslint"],
+          "packagePatterns": ["^babel"]
         },
         {
           "groupName": "rollup packages",
-          "packagePatterns": [
-            "^rollup"
-          ]
+          "packagePatterns": ["^rollup"]
         },
         {
           "groupName": "react",
           "description": "react monorepo",
-          "sourceUrlPrefixes": [
-            "https://github.com/facebook/react"
-          ],
-          "packageNames": [
-            "@hot-loader/react-dom",
-            "@types/react",
-            "@types/react-dom"
-          ]
+          "sourceUrlPrefixes": ["https://github.com/facebook/react"],
+          "packageNames": ["@hot-loader/react-dom", "@types/react", "@types/react-dom"]
         },
         {
-          "packageNames": [
-            "husky",
-            "lint-staged",
-            "prettier",
-            "yarn-update-lock",
-            "yarnhook"
-          ],
-          "packagePatterns": [
-            "^@commitlint",
-            "^eslint"
-          ],
-          "updateTypes": [
-            "patch",
-            "minor"
-          ],
-          "labels": [
-            ":ok_hand: code/approved",
-            ":soon: automerge"
-          ],
+          "packageNames": ["husky", "lint-staged", "prettier", "yarnhook"],
+          "packagePatterns": ["^@commitlint", "^eslint"],
+          "updateTypes": ["patch", "minor"],
+          "labels": [":ok_hand: code/approved", ":soon: automerge"],
           "masterIssueApproval": false,
-          "schedule": [
-            "before 5:00am"
-          ]
+          "schedule": ["before 5:00am"]
         },
         {
-          "packagePatterns": [
-            "^@types"
-          ],
-          "updateTypes": [
-            "patch"
-          ],
-          "labels": [
-            ":ok_hand: code/approved",
-            ":soon: automerge"
-          ],
+          "packagePatterns": ["^@types"],
+          "updateTypes": ["patch"],
+          "labels": [":ok_hand: code/approved", ":soon: automerge"],
           "masterIssueApproval": false,
-          "schedule": [
-            "before 5:00am"
-          ]
+          "schedule": ["before 5:00am"]
         },
         {
-          "updateTypes": [
-            "pin"
-          ],
-          "labels": [
-            ":ok_hand: code/approved",
-            ":soon: automerge"
-          ],
+          "updateTypes": ["pin"],
+          "labels": [":ok_hand: code/approved", ":soon: automerge"],
           "masterIssueApproval": false,
-          "schedule": [
-            "at any time"
-          ]
+          "schedule": ["at any time"]
         },
         {
-          "updateTypes": [
-            "major"
-          ],
-          "schedule": [
-            "at any time"
-          ],
+          "updateTypes": ["major"],
+          "schedule": ["at any time"],
           "masterIssueApproval": true
         }
       ]

--- a/@ornikar/repo-config/createLintStagedConfig.js
+++ b/@ornikar/repo-config/createLintStagedConfig.js
@@ -19,7 +19,8 @@ module.exports = function createLintStagedConfig(options = {}) {
     }}`]: (filenames) => {
       const packagejsonFilenames = filenames.filter((filename) => filename.endsWith('.json'));
       return [
-        'yarn-update-lock',
+        'yarn --prefer-offline',
+        'yarn-deduplicate',
         packagejsonFilenames.length === 0
           ? undefined
           : `prettier --parser json --write ${packagejsonFilenames.join(' ')}`,

--- a/@ornikar/repo-config/package.json
+++ b/@ornikar/repo-config/package.json
@@ -18,6 +18,6 @@
     "@ornikar/commitlint-config": "^1.0.0",
     "cross-env": "^6.0.3",
     "lint-staged": "9.5.0",
-    "yarn-update-lock": "1.0.0"
+    "yarn-deduplicate": "1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lerna": "3.19.0",
     "lint-staged": "9.5.0",
     "prettier": "1.19.1",
-    "yarn-update-lock": "1.0.0",
+    "yarn-deduplicate": "1.1.1",
     "yarnhook": "0.4.3"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,22 @@
 {
-  "extends": ["config:js-lib", "@ornikar"]
+  "extends": ["config:js-lib", "@ornikar"],
+  "packageRules": [
+    {
+      "packageNames": [
+        "yarn-deduplicate"
+      ],
+      "updateTypes": [
+        "patch",
+        "minor"
+      ],
+      "labels": [
+        ":ok_hand: code/approved",
+        ":soon: automerge"
+      ],
+      "masterIssueApproval": false,
+      "schedule": [
+        "before 5:00am"
+      ]
+    }
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11193,7 +11193,7 @@ yargs@^14.2.2:
     y18n "^4.0.0"
     yargs-parser "^15.0.0"
 
-yarn-deduplicate@^1.1.1:
+yarn-deduplicate@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-1.1.1.tgz#19b4a87654b66f55bf3a4bd6b153b4e4ab1b6e6d"
   integrity sha512-2FDJ1dFmtvqhRmfja89ohYzpaheCYg7BFBSyaUq+kxK0y61C9oHv1XaQovCWGJtP2WU8PksQOgzMVV7oQOobzw==
@@ -11201,13 +11201,6 @@ yarn-deduplicate@^1.1.1:
     "@yarnpkg/lockfile" "^1.1.0"
     commander "^2.10.0"
     semver "^5.3.0"
-
-yarn-update-lock@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/yarn-update-lock/-/yarn-update-lock-1.0.0.tgz#2b06b953246770a93f85fe28eec8d78e94a0be84"
-  integrity sha512-eXbu2pbTKl61dmm4406qGP9VbPUdy9ZdQaAeS7iL4yQyap/4gKombMt9xddxqWGr4SZOaPb/qX1J825ihGQIiw==
-  dependencies:
-    yarn-deduplicate "^1.1.1"
 
 yarnhook@0.4.3:
   version "0.4.3"


### PR DESCRIPTION
Supprime une dep non nécéssaire !

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
