### PR TITLE
feat: ignore lifecycle methods warning in jest tests [no issue]

### DIFF
--- a/@ornikar/jest-config/test-setup-after-env.js
+++ b/@ornikar/jest-config/test-setup-after-env.js
@@ -10,9 +10,25 @@ const chalk = require('chalk');
 
 const env = jasmine.getEnv();
 
+// Deprecated lifecycle methods are forbidden in our eslint config. This means any related warning is due to a dependency and can be ignored in tests.
+const deprecatedReactLifeCycleMethods = [
+  'componentWillMount',
+  'componentWillUnmount',
+  'componentWillUpdate',
+  'componentWillReceiveProps',
+];
+
 ['error', 'warn'].forEach((methodName) => {
   const unexpectedConsoleCallStacks = [];
   const newMethod = function(format, ...args) {
+    if (
+      typeof format === 'string' &&
+      deprecatedReactLifeCycleMethods.some((lifecycleMethod) =>
+        format.includes(`${lifecycleMethod} has been renamed, and is not recommended for use.`),
+      )
+    ) {
+      return;
+    }
     // Capture the call stack now so we can warn about it later.
     // The call stack has helpful information for the test author.
     // Don't throw yet though b'c it might be accidentally caught and suppressed.


### PR DESCRIPTION
### Context

Some tests fail because react throws warning when libraries use deprecated lifecycle methods.

### Solution

Ignore those lifecycle warning in jest tests, they are already forbidden by our eslint config.

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
