### PR TITLE
feat(intl-config): add babelPluginReactIntlOptions in generate-translations script [no issue]

### DIFF
--- a/@ornikar/intl-config/generate-translations.js
+++ b/@ornikar/intl-config/generate-translations.js
@@ -10,8 +10,8 @@ const babelPluginReactIntl = require('babel-plugin-react-intl');
 
 process.env.NODE_ENV = 'production';
 
-module.exports = ({ paths, babelConfig, defaultDestinationDirectory }) => {
-  const babelPlugins = [babelPluginReactIntl, ...(babelConfig.plugins || [])];
+module.exports = ({ paths, babelConfig, babelPluginReactIntlOptions = {}, defaultDestinationDirectory }) => {
+  const babelPlugins = [[babelPluginReactIntl, babelPluginReactIntlOptions], ...(babelConfig.plugins || [])];
   paths.forEach(({ name, messageGlob, destinationDirectory = defaultDestinationDirectory }) => {
     const defaultMessages = globSync(messageGlob, { ignore: ['**/*.module.css.d.ts', '**/stories.{ts,tsx,js,jsx}', '**/*.{test.ts,test.tsx,test.js,test.jsx}'] })
       .map((filename) => ({ filename, code: fs.readFileSync(filename, 'utf8') }))


### PR DESCRIPTION
Pour un test j'ai besoin de passer des options au plugin babel

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [x] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
