### PR TITLE
fix: recursive warn [no issue]

### DIFF
--- a/@ornikar/jest-config/test-setup-after-env.js
+++ b/@ornikar/jest-config/test-setup-after-env.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 'use strict';
 
 /* global jasmine */
@@ -19,7 +21,7 @@ const deprecatedReactLifeCycleMethods = [
 ];
 
 ['error', 'warn'].forEach((methodName) => {
-  const originalConsole = console;
+  const originalMethod = console[methodName];
 
   const unexpectedConsoleCallStacks = [];
   const newMethod = function(format, ...args) {
@@ -33,7 +35,7 @@ const deprecatedReactLifeCycleMethods = [
       }
 
       if (format.match(/Warning: An update to (.*) inside a test was not wrapped in act/)) {
-        originalConsole.warn(format, ...args);
+        originalMethod(format, ...args);
         return;
       }
     }


### PR DESCRIPTION
### Context

~Je sais pas comment ca pouvait marcher avant, mais~ j'ai des calls stack recursive sur certaines versions de node 10 et 12

```
    RangeError: Maximum call stack size exceeded

      at deprecatedReactLifeCycleMethods.some (node_modules/@ornikar/jest-config/test-setup-after-env.js:28:46)
          at Array.some (<anonymous>)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:28:41)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
      at BufferedConsole.newMethod [as warn] (node_modules/@ornikar/jest-config/test-setup-after-env.js:36:25)
```


<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
