### PR TITLE
feat(rollup-config): packages filter ignore name starting with .eslintrc [no issue]

### DIFF
--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -139,7 +139,7 @@ module.exports = (packagesDir = '@ornikar') => {
     ? [process.env.ORNIKAR_ONLY]
     : fs
         .readdirSync(path.resolve(`./${packagesDir}`))
-        .filter((packageName) => packageName !== '.DS_Store' && packageName !== '.eslintrc.json');
+        .filter((name) => name !== '.DS_Store' && !name.startsWith('.eslintrc'));
 
   return [].concat(...packages.map((packageName) => createBuildsForPackage(packagesDir, packageName)));
 };


### PR DESCRIPTION
### Context

ignore `.eslintrc.project.json` that I added in components in https://github.com/ornikar/components/pull/450

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [x] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
