### PR TITLE
feat: use react testing library instead of enzyme ONK-4263

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -47,7 +47,7 @@ exports.storiesOf = (groupName) => {
     add(storyName, story, storyParameters = {}) {
       const parameters = { name: storyName, ...localParameters, ...storyParameters };
       const { jest } = parameters;
-      const { componentToTest, ignore, ignoreDecorators, testingLibrary } = jest || {};
+      const { componentToTest, ignore, ignoreDecorators, useDeprecatedEnzyme } = jest || {};
 
       if (ignore) {
         test.skip(storyName, () => {});
@@ -60,10 +60,7 @@ exports.storiesOf = (groupName) => {
             ? undefined
             : ({ children }) => decorateStory(() => children, [...globalDecorators, ...localDecorators])(parameters);
 
-          if (testingLibrary) {
-            const { asFragment } = render(story(parameters), { wrapper: wrappingComponent });
-            expect(asFragment()).toMatchSnapshot();
-          } else {
+          if (useDeprecatedEnzyme) {
             const wrapper = shallow(story(parameters), {
               disableLifecycleMethods: true,
               wrappingComponent,
@@ -77,6 +74,9 @@ exports.storiesOf = (groupName) => {
             } else {
               expect(shallowToJson(wrapper)).toMatchSnapshot();
             }
+          } else {
+            const { asFragment } = render(story(parameters), { wrapper: wrappingComponent });
+            expect(asFragment()).toMatchSnapshot();
           }
         });
       });


### PR DESCRIPTION
### Context

We're currently generating snapshots from stories.
We used to do it using enzyme and in some cases, with react testing library.

-> We want to only use react testing library, so we make it the default behavior

See what we get with this : https://github.com/ornikar/learner-webapp/pull/827

### Solution

* Remove default enzyme ✂️ 
* Default to react-testing-library 🌠 


<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Infos:
[JIRA issue: ONK-4263](https://ornikar.atlassian.net/browse/ONK-4263)
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
