### PR TITLE
feat: improve snapshots from stories [no issue]

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const { render } = require('@testing-library/react');
+const { render, act } = require('@testing-library/react');
 
 const decorateStory = (storyFn, decorators) =>
   decorators.reduce(
@@ -58,9 +58,11 @@ exports.storiesOf = (groupName) => {
             ? undefined
             : ({ children }) => decorateStory(() => children, [...globalDecorators, ...localDecorators])(parameters);
 
-          const { unmount, asFragment } = render(story(parameters), { wrapper: wrappingComponent });
-          expect(asFragment()).toMatchSnapshot();
-          unmount();
+          act(() => {
+            const { unmount, asFragment } = render(story(parameters), { wrapper: wrappingComponent });
+            expect(asFragment()).toMatchSnapshot();
+            unmount();
+          });
         });
       });
 


### PR DESCRIPTION
### Context

Identification de la majorité des erreurs d'act qu'on a:

c'est la validation qui pose probleme
- l'etat initial du field est toujours invalid: false
- il passe a invalid: true (required)
- la validation n'est pas fait lors de la creation du champ, a cause du blocage: https://github.com/final-form/react-final-form/blob/master/src/ReactFinalForm.js#L72
- il passe a invalid: true suite à https://github.com/final-form/react-final-form/blob/master/src/ReactFinalForm.js#L93

D'autres rerender sont triggers pour d'autres raisons (composant AudioCorrectionButton par exemple) donc on ne peut pas thrower ces erreurs
J'ai pas trouvé la possibilité d'ignorer tous les warning quand ca vient des stories (ca serait l'idéal)
Je pense qu'il faut quand même les afficher pour les tests qui ne sont pas fait via les stories
Wrapper toutes les stories par act permet d'avoir des snapshots plus représentatif du premier etat du composant que va voir l'utilisateur

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
