### PR TITLE
fix: unmount components after rendering them [no issue]

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -58,8 +58,9 @@ exports.storiesOf = (groupName) => {
             ? undefined
             : ({ children }) => decorateStory(() => children, [...globalDecorators, ...localDecorators])(parameters);
 
-          const { asFragment } = render(story(parameters), { wrapper: wrappingComponent });
+          const { unmount, asFragment } = render(story(parameters), { wrapper: wrappingComponent });
           expect(asFragment()).toMatchSnapshot();
+          unmount();
         });
       });
 


### PR DESCRIPTION
### Context

Prevents unwanted errors, because cleanup effects are not triggered

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
