### PR TITLE
feat: remove intl polyfill [no issue]

### DIFF
--- a/@ornikar/jest-config/package.json
+++ b/@ornikar/jest-config/package.json
@@ -12,9 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@formatjs/intl-pluralrules": "1.5.2",
     "chalk": "^4.0.0",
-    "intl": "^1.2.5",
     "timezone-mock": "^1.0.5"
   },
   "peerDependencies": {

--- a/@ornikar/jest-config/test-shim.js
+++ b/@ornikar/jest-config/test-shim.js
@@ -1,17 +1,5 @@
 'use strict';
 
-/* Always load Intl Polyfill */
-const IntlPolyfill = require('intl');
-require('intl/locale-data/jsonp/fr');
-
-global.Intl = IntlPolyfill;
-// order matters because formatjs polyfill changes global Intl object
-require('@formatjs/intl-pluralrules/polyfill');
-require('@formatjs/intl-pluralrules/dist/locale-data/fr');
-
-global.NumberFormat = IntlPolyfill.NumberFormat;
-global.DateTimeFormat = IntlPolyfill.DateTimeFormat;
-
 global.requestAnimationFrame = (callback) => {
   setTimeout(callback, 0);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,13 +510,6 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@formatjs/intl-pluralrules@1.5.2":
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.2.tgz#3e37f38e21b6a30c484e9138187d0a1a4b0d1f76"
-  integrity sha512-kxCufLRBOaj9x4PP2QrYmYSmr2WfJnBmUx/6eaajuaHlXTfXvLD1Dz/s1YBXHipOlorh51ehHQPoRgrOCNNpkA==
-  dependencies:
-    "@formatjs/intl-utils" "^2.2.0"
-
 "@formatjs/intl-unified-numberformat@^3.1.0", "@formatjs/intl-unified-numberformat@^3.3.3":
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-3.3.3.tgz#c0006fb06588ccce614df50f3469ca2ec92816f2"
@@ -524,7 +517,7 @@
   dependencies:
     "@formatjs/intl-utils" "^2.2.2"
 
-"@formatjs/intl-utils@^2.2.0", "@formatjs/intl-utils@^2.2.2":
+"@formatjs/intl-utils@^2.2.2":
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-2.2.2.tgz#adc448035c2e3f60c550bd27c97eca336e641f5a"
   integrity sha512-rKINaMRYH3FeNwYjEQwPtsA0kP2/hLLMB9mLi/QYfszz/huTqkInFmYilFRCX4oLlhFXDK5UQQMGNfEavN02Sg==
@@ -5697,11 +5690,6 @@ intl-messageformat-parser@^5.0.0:
   integrity sha512-2JwOxRl/1rm+03dJ+ZSOVbFpdPepgEBLuThkeJwBBUzHf53OiZ1FN8kkXTe7WrWLlg+alGsSEMZwTeqpoqvgLw==
   dependencies:
     "@formatjs/intl-unified-numberformat" "^3.3.3"
-
-intl@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
-  integrity sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94=
 
 invariant@2.2.4, invariant@^2.2.3:
   version "2.2.4"


### PR DESCRIPTION
Since node 12, we no longer need polyfills, just node-icu to load fr data

BREAKING CHANGE: project should add a devdep to node-icu and run commands with NODE_ICU_DATA env variable

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Commits Notes:

Breaking Changes:
- project should add a devdep to node-icu and run commands with NODE_ICU_DATA env variable (45bf7ab787976a6b40f0862185f163cc1a04c77c)

#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
