### PR TITLE
fix: tsconfig generator [no issue]

### DIFF
--- a/@ornikar/lerna-config/generate-tsconfig-files.js
+++ b/@ornikar/lerna-config/generate-tsconfig-files.js
@@ -36,7 +36,10 @@ const PackageGraph = require('@lerna/package-graph');
       extends: '../../tsconfig.base.json',
       compilerOptions: {
         rootDirs: ['src'],
-        baseUrl: '.',
+        baseUrl: './src',
+        paths: {
+          [pkg.name]: ['./index.ts'],
+        },
       },
       include: ['src', '../../typings'],
     };
@@ -50,10 +53,19 @@ const PackageGraph = require('@lerna/package-graph');
         isolatedModules: false,
         emitDeclarationOnly: true,
         declarationMap: true,
-        outDir: 'dist',
+        outDir: 'dist/definitions',
         tsBuildInfoFile: 'dist/tsbuildinfo',
       },
-      exclude: ['dist', '*.test.ts'],
+      exclude: [
+        'dist',
+        '**/__mocks__',
+        '**/__tests__',
+        '**/*.test.ts',
+        '**/*.test.tsx',
+        '**/stories.ts',
+        '**/stories.tsx',
+        '**/stories/**',
+      ],
     };
 
     const dependencies = packages.filter((dep) => {
@@ -71,10 +83,9 @@ const PackageGraph = require('@lerna/package-graph');
     }
 
     if (dependencies.length !== 0) {
-      tsconfigContent.compilerOptions.paths = {};
       dependencies.forEach((pkgDep) => {
-        const depPath = `../../${pkgDep.name}/src`;
-        tsconfigContent.compilerOptions.paths[pkgDep.name] = [depPath];
+        const depPath = `../../../${pkgDep.name}/src`;
+        tsconfigContent.compilerOptions.paths[pkgDep.name] = [`${depPath}/index.ts`];
         tsconfigContent.compilerOptions.rootDirs.push(depPath);
       });
       tsconfigBuildContent.references = dependencies.map((pkgDep) => ({


### PR DESCRIPTION
### Context

allow @ornikar/shared-config to work on both components and kitt

### Solution

- allow to import the current package directly (used in kitt in stories to target built file, but tsc should target src)
- build definitions in dist/definitions (breaking)
- add files in exclude

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
