### PR TITLE
feat: avoir typing return type when expression typed [no issue]

### DIFF
--- a/@ornikar/eslint-config-typescript/plugins/typescript-eslint.js
+++ b/@ornikar/eslint-config-typescript/plugins/typescript-eslint.js
@@ -110,7 +110,7 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': [
       'warn',
       {
-        allowExpressions: false,
+        allowExpressions: true,
         allowTypedFunctionExpressions: true,
         allowHigherOrderFunctions: true,
       },


### PR DESCRIPTION
### Context

Examples of correct code for this rule with { allowExpressions: true }:

```
node.addEventListener('click', () => {});

node.addEventListener('click', function () {});
```

Aujourdhui on doit faire:


```
node.addEventListener('click', (): void => {});

node.addEventListener('click', function (): void {});
```




<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
