### PR TITLE
feat: support node 12.16.1 for renovate [no issue]

### DIFF
--- a/@ornikar/browserslist-config/package.json
+++ b/@ornikar/browserslist-config/package.json
@@ -6,7 +6,7 @@
   "main": "degraded-support.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/commitlint-config/package.json
+++ b/@ornikar/commitlint-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-babel-use/package.json
+++ b/@ornikar/eslint-config-babel-use/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-babel/package.json
+++ b/@ornikar/eslint-config-babel/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-formatjs/package.json
+++ b/@ornikar/eslint-config-formatjs/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-node/package.json
+++ b/@ornikar/eslint-config-node/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-react/package.json
+++ b/@ornikar/eslint-config-react/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-typescript-react/package.json
+++ b/@ornikar/eslint-config-typescript-react/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-typescript/package.json
+++ b/@ornikar/eslint-config-typescript/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config/package.json
+++ b/@ornikar/eslint-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/intl-config/package.json
+++ b/@ornikar/intl-config/package.json
@@ -5,7 +5,7 @@
   "repository": "ornikar/shared-configs",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/jest-config-react/package.json
+++ b/@ornikar/jest-config-react/package.json
@@ -6,7 +6,7 @@
   "main": "jest-preset.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/jest-config/package.json
+++ b/@ornikar/jest-config/package.json
@@ -6,7 +6,7 @@
   "main": "jest-preset.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/lerna-config/package.json
+++ b/@ornikar/lerna-config/package.json
@@ -5,7 +5,7 @@
   "repository": "ornikar/shared-configs",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/postcss-config/package.json
+++ b/@ornikar/postcss-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/prettier-config/package.json
+++ b/@ornikar/prettier-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -3,7 +3,7 @@
   "version": "2.2.0",
   "description": "renovate shared config",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"
@@ -17,15 +17,11 @@
       "masterIssueApproval": true,
       "rebaseStalePrs": true,
       "updateNotScheduled": false,
-      "postUpdateOptions": [
-        "yarnDedupeHighest"
-      ],
+      "postUpdateOptions": ["yarnDedupeHighest"],
       "prBodyNotes": [
         "<!-- do not edit after this -->This will be auto filled by reviewflow.<!-- end - don't add anything after this -->"
       ],
-      "labels": [
-        ":soon: automerge"
-      ],
+      "labels": [":soon: automerge"],
       "packageRules": [
         {
           "groupName": "Lint Ornikar Shared Configs",
@@ -39,15 +35,10 @@
             "@ornikar/prettier-config",
             "@ornikar/stylelint-config"
           ],
-          "labels": [
-            ":ok_hand: code/approved",
-            ":soon: automerge"
-          ],
+          "labels": [":ok_hand: code/approved", ":soon: automerge"],
           "rebaseStalePrs": false,
           "masterIssueApproval": false,
-          "schedule": [
-            "at any time"
-          ]
+          "schedule": ["at any time"]
         },
         {
           "groupName": "Repo Shared Configs Ornikar",
@@ -57,28 +48,17 @@
             "@ornikar/repo-config",
             "@ornikar/repo-config-react"
           ],
-          "labels": [
-            ":ok_hand: code/approved",
-            ":soon: automerge"
-          ],
+          "labels": [":ok_hand: code/approved", ":soon: automerge"],
           "rebaseStalePrs": false,
           "masterIssueApproval": false,
-          "schedule": [
-            "at any time"
-          ]
+          "schedule": ["at any time"]
         },
         {
           "groupName": "Build Shared Configs Ornikar",
-          "packageNames": [
-            "@ornikar/rollup-config",
-            "@ornikar/storybook-config",
-            "@ornikar/webpack-config"
-          ],
+          "packageNames": ["@ornikar/rollup-config", "@ornikar/storybook-config", "@ornikar/webpack-config"],
           "rebaseStalePrs": false,
           "masterIssueApproval": false,
-          "schedule": [
-            "at any time"
-          ]
+          "schedule": ["at any time"]
         },
         {
           "groupName": "Components Ornikar",
@@ -94,109 +74,53 @@
           ],
           "rebaseStalePrs": false,
           "masterIssueApproval": false,
-          "schedule": [
-            "at any time"
-          ]
+          "schedule": ["at any time"]
         },
         {
           "groupName": "eslint packages",
-          "packageNames": [
-            "babel-eslint"
-          ],
-          "packagePatterns": [
-            "^eslint"
-          ]
+          "packageNames": ["babel-eslint"],
+          "packagePatterns": ["^eslint"]
         },
         {
           "groupName": "babel community packages",
-          "excludePackageNames": [
-            "babel-eslint"
-          ],
-          "packagePatterns": [
-            "^babel"
-          ]
+          "excludePackageNames": ["babel-eslint"],
+          "packagePatterns": ["^babel"]
         },
         {
           "groupName": "rollup packages",
-          "packagePatterns": [
-            "^rollup"
-          ]
+          "packagePatterns": ["^rollup"]
         },
         {
           "groupName": "react",
           "description": "react monorepo",
-          "sourceUrlPrefixes": [
-            "https://github.com/facebook/react"
-          ],
-          "packageNames": [
-            "@hot-loader/react-dom",
-            "@types/react",
-            "@types/react-dom"
-          ]
+          "sourceUrlPrefixes": ["https://github.com/facebook/react"],
+          "packageNames": ["@hot-loader/react-dom", "@types/react", "@types/react-dom"]
         },
         {
-          "packageNames": [
-            "husky",
-            "lint-staged",
-            "prettier",
-            "yarn-deduplicate",
-            "yarnhook"
-          ],
-          "packagePatterns": [
-            "^@commitlint",
-            "^eslint"
-          ],
-          "updateTypes": [
-            "patch",
-            "minor"
-          ],
-          "labels": [
-            ":ok_hand: code/approved",
-            ":soon: automerge"
-          ],
+          "packageNames": ["husky", "lint-staged", "prettier", "yarn-update-lock", "yarnhook"],
+          "packagePatterns": ["^@commitlint", "^eslint"],
+          "updateTypes": ["patch", "minor"],
+          "labels": [":ok_hand: code/approved", ":soon: automerge"],
           "masterIssueApproval": false,
-          "schedule": [
-            "before 5:00am"
-          ]
+          "schedule": ["before 5:00am"]
         },
         {
-          "packagePatterns": [
-            "^@types"
-          ],
-          "updateTypes": [
-            "patch"
-          ],
-          "labels": [
-            ":ok_hand: code/approved",
-            ":soon: automerge"
-          ],
+          "packagePatterns": ["^@types"],
+          "updateTypes": ["patch"],
+          "labels": [":ok_hand: code/approved", ":soon: automerge"],
           "masterIssueApproval": false,
-          "schedule": [
-            "before 5:00am"
-          ]
+          "schedule": ["before 5:00am"]
         },
         {
-          "updateTypes": [
-            "pin"
-          ],
-          "labels": [
-            ":ok_hand: code/approved",
-            ":soon: automerge"
-          ],
+          "updateTypes": ["pin"],
+          "labels": [":ok_hand: code/approved", ":soon: automerge"],
           "masterIssueApproval": false,
-          "schedule": [
-            "at any time"
-          ]
+          "schedule": ["at any time"]
         },
         {
-          "updateTypes": [
-            "major"
-          ],
-          "schedule": [
-            "at any time"
-          ],
-          "masterIssueApproval": true,
-          "rangeStrategy": "bump"
+          "updateTypes": ["major"],
+          "schedule": ["at any time"],
+          "masterIssueApproval": true
         }
       ]
     }

--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -17,11 +17,15 @@
       "masterIssueApproval": true,
       "rebaseStalePrs": true,
       "updateNotScheduled": false,
-      "postUpdateOptions": ["yarnDedupeHighest"],
+      "postUpdateOptions": [
+        "yarnDedupeHighest"
+      ],
       "prBodyNotes": [
         "<!-- do not edit after this -->This will be auto filled by reviewflow.<!-- end - don't add anything after this -->"
       ],
-      "labels": [":soon: automerge"],
+      "labels": [
+        ":soon: automerge"
+      ],
       "packageRules": [
         {
           "groupName": "Lint Ornikar Shared Configs",
@@ -35,10 +39,15 @@
             "@ornikar/prettier-config",
             "@ornikar/stylelint-config"
           ],
-          "labels": [":ok_hand: code/approved", ":soon: automerge"],
+          "labels": [
+            ":ok_hand: code/approved",
+            ":soon: automerge"
+          ],
           "rebaseStalePrs": false,
           "masterIssueApproval": false,
-          "schedule": ["at any time"]
+          "schedule": [
+            "at any time"
+          ]
         },
         {
           "groupName": "Repo Shared Configs Ornikar",
@@ -48,17 +57,28 @@
             "@ornikar/repo-config",
             "@ornikar/repo-config-react"
           ],
-          "labels": [":ok_hand: code/approved", ":soon: automerge"],
+          "labels": [
+            ":ok_hand: code/approved",
+            ":soon: automerge"
+          ],
           "rebaseStalePrs": false,
           "masterIssueApproval": false,
-          "schedule": ["at any time"]
+          "schedule": [
+            "at any time"
+          ]
         },
         {
           "groupName": "Build Shared Configs Ornikar",
-          "packageNames": ["@ornikar/rollup-config", "@ornikar/storybook-config", "@ornikar/webpack-config"],
+          "packageNames": [
+            "@ornikar/rollup-config",
+            "@ornikar/storybook-config",
+            "@ornikar/webpack-config"
+          ],
           "rebaseStalePrs": false,
           "masterIssueApproval": false,
-          "schedule": ["at any time"]
+          "schedule": [
+            "at any time"
+          ]
         },
         {
           "groupName": "Components Ornikar",
@@ -74,52 +94,107 @@
           ],
           "rebaseStalePrs": false,
           "masterIssueApproval": false,
-          "schedule": ["at any time"]
+          "schedule": [
+            "at any time"
+          ]
         },
         {
           "groupName": "eslint packages",
-          "packageNames": ["babel-eslint"],
-          "packagePatterns": ["^eslint"]
+          "packageNames": [
+            "babel-eslint"
+          ],
+          "packagePatterns": [
+            "^eslint"
+          ]
         },
         {
           "groupName": "babel community packages",
-          "excludePackageNames": ["babel-eslint"],
-          "packagePatterns": ["^babel"]
+          "excludePackageNames": [
+            "babel-eslint"
+          ],
+          "packagePatterns": [
+            "^babel"
+          ]
         },
         {
           "groupName": "rollup packages",
-          "packagePatterns": ["^rollup"]
+          "packagePatterns": [
+            "^rollup"
+          ]
         },
         {
           "groupName": "react",
           "description": "react monorepo",
-          "sourceUrlPrefixes": ["https://github.com/facebook/react"],
-          "packageNames": ["@hot-loader/react-dom", "@types/react", "@types/react-dom"]
+          "sourceUrlPrefixes": [
+            "https://github.com/facebook/react"
+          ],
+          "packageNames": [
+            "@hot-loader/react-dom",
+            "@types/react",
+            "@types/react-dom"
+          ]
         },
         {
-          "packageNames": ["husky", "lint-staged", "prettier", "yarn-update-lock", "yarnhook"],
-          "packagePatterns": ["^@commitlint", "^eslint"],
-          "updateTypes": ["patch", "minor"],
-          "labels": [":ok_hand: code/approved", ":soon: automerge"],
+          "packageNames": [
+            "husky",
+            "lint-staged",
+            "prettier",
+            "yarn-update-lock",
+            "yarnhook"
+          ],
+          "packagePatterns": [
+            "^@commitlint",
+            "^eslint"
+          ],
+          "updateTypes": [
+            "patch",
+            "minor"
+          ],
+          "labels": [
+            ":ok_hand: code/approved",
+            ":soon: automerge"
+          ],
           "masterIssueApproval": false,
-          "schedule": ["before 5:00am"]
+          "schedule": [
+            "before 5:00am"
+          ]
         },
         {
-          "packagePatterns": ["^@types"],
-          "updateTypes": ["patch"],
-          "labels": [":ok_hand: code/approved", ":soon: automerge"],
+          "packagePatterns": [
+            "^@types"
+          ],
+          "updateTypes": [
+            "patch"
+          ],
+          "labels": [
+            ":ok_hand: code/approved",
+            ":soon: automerge"
+          ],
           "masterIssueApproval": false,
-          "schedule": ["before 5:00am"]
+          "schedule": [
+            "before 5:00am"
+          ]
         },
         {
-          "updateTypes": ["pin"],
-          "labels": [":ok_hand: code/approved", ":soon: automerge"],
+          "updateTypes": [
+            "pin"
+          ],
+          "labels": [
+            ":ok_hand: code/approved",
+            ":soon: automerge"
+          ],
           "masterIssueApproval": false,
-          "schedule": ["at any time"]
+          "schedule": [
+            "at any time"
+          ]
         },
         {
-          "updateTypes": ["major"],
-          "schedule": ["at any time"],
+          "updateTypes": [
+            "major"
+          ],
+          "schedule": [
+            "at any time"
+          ],
           "masterIssueApproval": true
         }
       ]

--- a/@ornikar/repo-config-react/package.json
+++ b/@ornikar/repo-config-react/package.json
@@ -5,7 +5,7 @@
   "repository": "ornikar/shared-configs",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/repo-config/package.json
+++ b/@ornikar/repo-config/package.json
@@ -5,7 +5,7 @@
   "repository": "ornikar/shared-configs",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/rollup-config/package.json
+++ b/@ornikar/rollup-config/package.json
@@ -6,7 +6,7 @@
   "main": "createRollupConfig.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/stylelint-config/package.json
+++ b/@ornikar/stylelint-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "scripts": {
     "run-on-examples": "prettier --write --parser css ./examples/**/*.css && stylelint --fix ./examples"

--- a/@ornikar/webpack-config/package.json
+++ b/@ornikar/webpack-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.2"
+    "node": ">= 12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "prettier": "./@ornikar/prettier-config",
   "engines": {
-    "node": ">=12.16.2",
+    "node": ">= 12.16.1",
     "yarn": ">=1.10.1"
   },
   "eslintConfig": {


### PR DESCRIPTION
### Context

Some renovate prs fails because of node version: https://github.com/ornikar/components/pull/516#issuecomment-633433095

### Solution

requires node 12.16.1 instead of 12.16.2

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Auto merge with `[skip ci]`
- [x] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
