### PR TITLE
feat: testing final state [no issue]

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -3,7 +3,8 @@
 'use strict';
 
 const { render, waitFor } = require('@testing-library/react');
-const wait = require('waait');
+
+const wait = (amount = 0) => new Promise((resolve) => setTimeout(resolve, amount));
 
 const decorateStory = (storyFn, decorators) =>
   decorators.reduce(
@@ -61,8 +62,11 @@ exports.storiesOf = (groupName) => {
 
           const { unmount, asFragment } = render(story(parameters), { wrapper: wrappingComponent });
 
+          // https://www.apollographql.com/docs/react/development-testing/testing/#testing-final-state
           await waitFor(async () => {
-            await wait(0); // wait for response
+            // delays until the next "tick" of the event loop, and allows time
+            // for that Promise returned from MockedProvider to be fulfilled
+            await wait(0);
           });
 
           expect(asFragment()).toMatchSnapshot();

--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -2,7 +2,8 @@
 
 'use strict';
 
-const { render } = require('@testing-library/react');
+const { render, waitFor } = require('@testing-library/react');
+const wait = require('waait');
 
 const decorateStory = (storyFn, decorators) =>
   decorators.reduce(
@@ -53,12 +54,17 @@ exports.storiesOf = (groupName) => {
       }
 
       describe(groupName, () => {
-        it(storyName, () => {
+        it(storyName, async () => {
           const wrappingComponent = ignoreDecorators
             ? undefined
             : ({ children }) => decorateStory(() => children, [...globalDecorators, ...localDecorators])(parameters);
 
           const { unmount, asFragment } = render(story(parameters), { wrapper: wrappingComponent });
+
+          await waitFor(async () => {
+            await wait(0); // wait for response
+          });
+
           expect(asFragment()).toMatchSnapshot();
           unmount();
         });

--- a/@ornikar/jest-config-react/package.json
+++ b/@ornikar/jest-config-react/package.json
@@ -18,8 +18,7 @@
   },
   "dependencies": {
     "@ornikar/jest-config": "^5.1.0",
-    "identity-obj-proxy": "^3.0.0",
-    "waait": "1.0.5"
+    "identity-obj-proxy": "^3.0.0"
   },
   "devDependencies": {
     "@testing-library/react": "10.0.4",

--- a/@ornikar/jest-config-react/package.json
+++ b/@ornikar/jest-config-react/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "@ornikar/jest-config": "^5.1.0",
-    "identity-obj-proxy": "^3.0.0"
+    "identity-obj-proxy": "^3.0.0",
+    "waait": "1.0.5"
   },
   "devDependencies": {
     "@testing-library/react": "10.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3902,17 +3902,10 @@ eslint-plugin-prefer-class-properties@^1.0.0:
   dependencies:
     requireindex "~1.1.0"
 
-eslint-plugin-prettier@3.1.4:
+eslint-plugin-prettier@3.1.4, eslint-plugin-prettier@^3.1.1:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"
   integrity sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
-eslint-plugin-prettier@^3.1.1:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz#ae116a0fc0e598fdae48743a4430903de5b4e6ca"
-  integrity sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -9959,11 +9952,6 @@ vfile@^3.0.0:
     replace-ext "1.0.0"
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
-
-waait@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/waait/-/waait-1.0.5.tgz#6a3c7aaa88bd0a1a545e9d47890b9595bebf9aa7"
-  integrity sha512-wp+unA4CpqxvBUKHHv8D86fK4jWByHAWyhEXXVHfVUZfK+16ylpj7hjQ58Z8j9ntu8XNukRQT8Fi5qbyJ8rkyw==
 
 warning@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9960,6 +9960,11 @@ vfile@^3.0.0:
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
 
+waait@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/waait/-/waait-1.0.5.tgz#6a3c7aaa88bd0a1a545e9d47890b9595bebf9aa7"
+  integrity sha512-wp+unA4CpqxvBUKHHv8D86fK4jWByHAWyhEXXVHfVUZfK+16ylpj7hjQ58Z8j9ntu8XNukRQT8Fi5qbyJ8rkyw==
+
 warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"


### PR DESCRIPTION
### Context

We have a lot of snapshots showing loading state or empty component because apollo is not in its final state

### Solution

> Loading state, while important, isn't the only thing to test. To test the final state of the component after receiving data, we can just wait for it to update and test the final state.

> Here, you can see the await wait(0) line. This is a utility function from the waait npm package. It delays until the next "tick" of the event loop, and allows time for that Promise returned from MockedProvider to be fulfilled. After that Promise resolves (or rejects), the component can be checked to ensure it displays the correct information — in this case, "Buck is a poodle".

From https://www.apollographql.com/docs/react/development-testing/testing/#testing-final-state

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Add `[skip ci]` on merge commit
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
