### PR TITLE
fix: reverse decorators array [no issue]

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -7,7 +7,7 @@ const { render } = require('@testing-library/react');
 const wait = (amount = 0) => new Promise((resolve) => setTimeout(resolve, amount));
 
 const decorateStory = (storyFn, decorators) =>
-  decorators.reverse.reduce(
+  decorators.reverse().reduce(
     (decorated, decorator) => (context = {}) =>
       decorator(
         (p = {}) =>

--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -7,7 +7,7 @@ const { render } = require('@testing-library/react');
 const wait = (amount = 0) => new Promise((resolve) => setTimeout(resolve, amount));
 
 const decorateStory = (storyFn, decorators) =>
-  decorators.reduce(
+  decorators.reverse.reduce(
     (decorated, decorator) => (context = {}) =>
       decorator(
         (p = {}) =>
@@ -66,7 +66,7 @@ exports.storiesOf = (groupName) => {
           // delays until the next "tick" of the event loop, and allows time
           // for that Promise returned from MockedProvider to be fulfilled
           await wait(0);
-          
+
           expect(asFragment()).toMatchSnapshot();
           unmount();
         });


### PR DESCRIPTION
### Context

Decorators are not well stacked – we sometimes need a context in a child decorator

Is:

```jsx
<DecoratorUsingProvider>
  <Provider>
    <Story />
  </Provider>
</DecoratorUsingProvider>
```

Should be:

```jsx
<Provider>
  <DecoratorUsingProvider>
    <Story />
  </DecoratorUsingProvider>
</Provider>
```

### Solution

Reverse decorators array

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Add `[skip ci]` on merge commit
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
