### PR TITLE
fix: reverse global and local decorators for tests [no issue]

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -7,7 +7,7 @@ const { render } = require('@testing-library/react');
 const wait = (amount = 0) => new Promise((resolve) => setTimeout(resolve, amount));
 
 const decorateStory = (storyFn, decorators) =>
-  decorators.reverse().reduce(
+  decorators.reduce(
     (decorated, decorator) => (context = {}) =>
       decorator(
         (p = {}) =>
@@ -58,7 +58,7 @@ exports.storiesOf = (groupName) => {
         it(storyName, async () => {
           const wrappingComponent = ignoreDecorators
             ? undefined
-            : ({ children }) => decorateStory(() => children, [...globalDecorators, ...localDecorators])(parameters);
+            : ({ children }) => decorateStory(() => children, [...localDecorators, ...globalDecorators])(parameters);
 
           const { unmount, asFragment } = render(story(parameters), { wrapper: wrappingComponent });
 


### PR DESCRIPTION
### Context

When we reverse all the decorators array, we are going against the decorator logic that put every new decorator around the next one.

We need to keep this to make storybook and tests work together.

We still want to stack global decorators first.

### Solution

```diff
- [...globalDecorators, ...localDecorators]
+ [...localDecorators, ...globalDecorators]
```

As `decorateStory` will stack them.


<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- do not edit after this -->
#### Options:
- [ ] <!-- reviewflow-featureBranch -->This PR is a feature branch
- [ ] <!-- reviewflow-autoMergeWithSkipCi -->Add `[skip ci]` on merge commit
- [ ] <!-- reviewflow-autoMerge -->Auto merge when this PR is ready and has no failed statuses. (Also has a queue per repo to prevent multiple useless "Update branch" triggers)
- [x] <!-- reviewflow-deleteAfterMerge -->Automatic branch delete after this PR is merged
<!-- end - don't add anything after this -->
