### PR TITLE
feat: act errors are not filtered anymore [no issue]

### DIFF
--- a/@ornikar/jest-config/test-setup-after-env.js
+++ b/@ornikar/jest-config/test-setup-after-env.js
@@ -33,11 +33,6 @@ const deprecatedReactLifeCycleMethods = [
       ) {
         return;
       }
-
-      if (format.match(/Warning: An update to (.*) inside a test was not wrapped in act/)) {
-        originalMethod(format, ...args);
-        return;
-      }
     }
     // Capture the call stack now so we can warn about it later.
     // The call stack has helpful information for the test author.

--- a/@ornikar/jest-config/test-setup-after-env.js
+++ b/@ornikar/jest-config/test-setup-after-env.js
@@ -21,8 +21,6 @@ const deprecatedReactLifeCycleMethods = [
 ];
 
 ['error', 'warn'].forEach((methodName) => {
-  const originalMethod = console[methodName];
-
   const unexpectedConsoleCallStacks = [];
   const newMethod = function (format, ...args) {
     if (typeof format === 'string') {


### PR DESCRIPTION
### Context

L'ensemble des erreurs `act` ont été corrigé sur la learner-webapp. On a donc plus besoin de transformer ces erreurs en warnings.

### Solution

Supprimer le bout de code qui transforme ces erreurs en warnings.


<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
