### PR TITLE
chore: lint all js files [no issue]

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/@ornikar/browserslist-config/package.json
+++ b/@ornikar/browserslist-config/package.json
@@ -6,7 +6,7 @@
   "main": "degraded-support.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/commitlint-config/package.json
+++ b/@ornikar/commitlint-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-babel-use/package.json
+++ b/@ornikar/eslint-config-babel-use/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-babel/package.json
+++ b/@ornikar/eslint-config-babel/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-formatjs/package.json
+++ b/@ornikar/eslint-config-formatjs/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-node/package.json
+++ b/@ornikar/eslint-config-node/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-node/plugins/node.js
+++ b/@ornikar/eslint-config-node/plugins/node.js
@@ -3,4 +3,10 @@
 module.exports = {
   plugins: ['node'],
   extends: ['plugin:node/recommended'],
+  rules: {
+    // already checked by import plugin
+    'node/no-unpublished-require': 'off',
+    'node/no-extraneous-require': 'off',
+    'node/no-missing-require': 'off',
+  },
 };

--- a/@ornikar/eslint-config-react/package.json
+++ b/@ornikar/eslint-config-react/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"
@@ -15,7 +15,7 @@
     "@ornikar/eslint-config-babel": "^10.1.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-config-prettier": "^6.7.0",
-    "eslint-plugin-react": "^7.19.0",
+    "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^2.5.0"
   },
   "peerDependencies": {

--- a/@ornikar/eslint-config-typescript-react/package.json
+++ b/@ornikar/eslint-config-typescript-react/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-typescript/package.json
+++ b/@ornikar/eslint-config-typescript/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config/package.json
+++ b/@ornikar/eslint-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config/plugins/unicorn.js
+++ b/@ornikar/eslint-config/plugins/unicorn.js
@@ -49,7 +49,7 @@ module.exports = {
     'unicorn/prefer-event-key': 'off',
 
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/prefer-flat-map.md
-    // TODO [engine:node@>=11] flatMap only supported from node 11
+    // TODO [engine:node@>=14] flatMap only supported from node 11
     'unicorn/prefer-flat-map': 'off',
 
     // https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-fn-reference-in-iterator.md

--- a/@ornikar/intl-config/package.json
+++ b/@ornikar/intl-config/package.json
@@ -5,7 +5,7 @@
   "repository": "ornikar/shared-configs",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/jest-config-react/package.json
+++ b/@ornikar/jest-config-react/package.json
@@ -6,7 +6,7 @@
   "main": "jest-preset.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/jest-config/package.json
+++ b/@ornikar/jest-config/package.json
@@ -6,7 +6,7 @@
   "main": "jest-preset.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/lerna-config/package.json
+++ b/@ornikar/lerna-config/package.json
@@ -5,7 +5,7 @@
   "repository": "ornikar/shared-configs",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/postcss-config/package.json
+++ b/@ornikar/postcss-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/prettier-config/package.json
+++ b/@ornikar/prettier-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -3,7 +3,7 @@
   "version": "2.6.0",
   "description": "renovate shared config",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/repo-config-react/package.json
+++ b/@ornikar/repo-config-react/package.json
@@ -5,7 +5,7 @@
   "repository": "ornikar/shared-configs",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/repo-config/package.json
+++ b/@ornikar/repo-config/package.json
@@ -5,7 +5,7 @@
   "repository": "ornikar/shared-configs",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/rollup-config/package.json
+++ b/@ornikar/rollup-config/package.json
@@ -6,7 +6,7 @@
   "main": "createRollupConfig.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/storybook-config/webpack-configs/base.js
+++ b/@ornikar/storybook-config/webpack-configs/base.js
@@ -3,6 +3,8 @@
 'use strict';
 
 const path = require('path');
+// webpack is a peer dependency, and we don't want to install it as dev dependency in this repo.
+// eslint-disable-next-line import/no-unresolved
 const webpack = require('webpack');
 const resolveFields = require('@ornikar/webpack-config/resolveFields');
 

--- a/@ornikar/stylelint-config/package.json
+++ b/@ornikar/stylelint-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "scripts": {
     "run-on-examples": "prettier --write --parser css ./examples/**/*.css && stylelint --fix ./examples"

--- a/@ornikar/webpack-config/package.json
+++ b/@ornikar/webpack-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">= 12.16.1"
+    "node": ">=12.16.1"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "private": true,
   "repository": "ornikar/shared-configs",
   "scripts": {
-    "lint": "eslint --ext .js --fix @ornikar/**/*.js",
+    "lint": "eslint --ext .js --fix .",
     "lint:prettier-json": "prettier --check {*.json,@ornikar/*/*.json}",
     "release": "lerna publish --conventional-commits -m 'chore: release'"
   },
   "prettier": "./@ornikar/prettier-config",
   "engines": {
-    "node": ">= 12.16.1",
+    "node": ">=12.16.1",
     "yarn": ">=1.10.1"
   },
   "eslintConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -149,7 +149,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
   integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
 
-"@babel/runtime-corejs3@^7.7.4", "@babel/runtime-corejs3@^7.8.3":
+"@babel/runtime-corejs3@^7.7.4":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.9.6.tgz#67aded13fffbbc2cb93247388cf84d77a4be9a71"
   integrity sha512-6toWAfaALQjt3KMZQc6fABqZwUDDuWzz+cAfPhqyEnzxvdWOAkjwPNxgF8xlmo7OWLsSjaKjsskpKHRLaMArOA==
@@ -2133,6 +2133,15 @@ array.prototype.flat@^1.2.3:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
+array.prototype.flatmap@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz#1c13f84a178566042dd63de4414440db9222e443"
+  integrity sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    function-bind "^1.1.1"
+
 arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -3849,29 +3858,10 @@ eslint-plugin-formatjs@^1.5.10:
     emoji-regex "^8.0.0"
     intl-messageformat-parser "^3.6.3"
 
-eslint-plugin-import@2.22.0:
+eslint-plugin-import@2.22.0, eslint-plugin-import@^2.20.2:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"
   integrity sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==
-  dependencies:
-    array-includes "^3.1.1"
-    array.prototype.flat "^1.2.3"
-    contains-path "^0.1.0"
-    debug "^2.6.9"
-    doctrine "1.5.0"
-    eslint-import-resolver-node "^0.3.3"
-    eslint-module-utils "^2.6.0"
-    has "^1.0.3"
-    minimatch "^3.0.4"
-    object.values "^1.1.1"
-    read-pkg-up "^2.0.0"
-    resolve "^1.17.0"
-    tsconfig-paths "^3.9.0"
-
-eslint-plugin-import@^2.20.2:
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.21.2.tgz#8fef77475cc5510801bedc95f84b932f7f334a7c"
-  integrity sha512-FEmxeGI6yaz+SnEB6YgNHlQK1Bs2DKLM+YF+vuTk5H8J9CLbJLtlPvRFgZZ2+sXiKAlN5dpdlrWOjK8ZoZJpQA==
   dependencies:
     array-includes "^3.1.1"
     array.prototype.flat "^1.2.3"
@@ -3933,23 +3923,22 @@ eslint-plugin-react-hooks@^2.5.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz#4ef5930592588ce171abeb26f400c7fbcbc23cd0"
   integrity sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==
 
-eslint-plugin-react@^7.19.0:
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz#6d08f9673628aa69c5559d33489e855d83551666"
-  integrity sha512-SPT8j72CGuAP+JFbT0sJHOB80TX/pu44gQ4vXH/cq+hQTiY2PuZ6IHkqXJV6x1b28GDdo1lbInjKUrrdUf0LOQ==
+eslint-plugin-react@^7.20.3:
+  version "7.20.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.20.3.tgz#0590525e7eb83890ce71f73c2cf836284ad8c2f1"
+  integrity sha512-txbo090buDeyV0ugF3YMWrzLIUqpYTsWSDZV9xLSmExE1P/Kmgg9++PD931r+KEWS66O1c9R4srLVVHmeHpoAg==
   dependencies:
     array-includes "^3.1.1"
+    array.prototype.flatmap "^1.2.3"
     doctrine "^2.1.0"
     has "^1.0.3"
-    jsx-ast-utils "^2.2.3"
-    object.entries "^1.1.1"
+    jsx-ast-utils "^2.4.1"
+    object.entries "^1.1.2"
     object.fromentries "^2.0.2"
     object.values "^1.1.1"
     prop-types "^15.7.2"
-    resolve "^1.15.1"
-    semver "^6.3.0"
+    resolve "^1.17.0"
     string.prototype.matchall "^4.0.2"
-    xregexp "^4.3.0"
 
 eslint-plugin-unicorn@14.0.1, eslint-plugin-unicorn@^14.0.1:
   version "14.0.1"
@@ -5763,12 +5752,12 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz#8a9364e402448a3ce7f14d357738310d9248054f"
-  integrity sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==
+jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz#1114a4c1209481db06c690c2b4f488cc665f657e"
+  integrity sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==
   dependencies:
-    array-includes "^3.0.3"
+    array-includes "^3.1.1"
     object.assign "^4.1.0"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
@@ -6787,14 +6776,13 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.entries@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.1.tgz#ee1cf04153de02bb093fec33683900f57ce5399b"
-  integrity sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==
+object.entries@^1.1.1, object.entries@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.2.tgz#bc73f00acb6b6bb16c203434b10f9a7e797d3add"
+  integrity sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==
   dependencies:
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
+    es-abstract "^1.17.5"
     has "^1.0.3"
 
 object.fromentries@^2.0.2:
@@ -8451,7 +8439,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.5.0:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.5.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -10155,13 +10143,6 @@ xmlbuilder@^4.1.0:
   integrity sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=
   dependencies:
     lodash "^4.0.0"
-
-xregexp@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.3.0.tgz#7e92e73d9174a99a59743f67a4ce879a04b5ae50"
-  integrity sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==
-  dependencies:
-    "@babel/runtime-corejs3" "^7.8.3"
 
 xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
### Context

While doing another PR (for data-testid), I saw that current config doesnt lint all js files.

### Solution

add eslintignore, lint "."

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
