### PR TITLE
fix(renovate): don't regroup eslint plugins for major updates [no issue]

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -100,6 +100,10 @@
         },
         {
           "groupName": "eslint packages",
+          "updateTypes": [
+            "patch",
+            "minor"
+          ],
           "packageNames": [
             "babel-eslint"
           ],


### PR DESCRIPTION
Allow to merge one by one (or only one)
