### PR TITLE
fix(jest-config-react): pass parameters in context object [no issue]

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -58,7 +58,7 @@ exports.storiesOf = (groupName) => {
         it(storyName, async () => {
           const wrappingComponent = ignoreDecorators
             ? undefined
-            : ({ children }) => decorateStory(() => children, [...localDecorators, ...globalDecorators])(parameters);
+            : ({ children }) => decorateStory(() => children, [...localDecorators, ...globalDecorators])({ parameters });
 
           await act(async () => {
             const { unmount, asFragment } = render(story(parameters), { wrapper: wrappingComponent });


### PR DESCRIPTION
### Context

Found this issue while updating ApolloDecorator.
`decorateStory` returns a function that take an object called context with inside another object called parameters, not parameters directly

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
