### PR TITLE
fix(jest-config-react): missing name in context [no issue]

### DIFF
--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -45,7 +45,8 @@ exports.storiesOf = (groupName) => {
   // Mocked API to generate tests from & snapshot stories.
   const api = {
     add(storyName, story, storyParameters = {}) {
-      const parameters = { name: storyName, ...localParameters, ...storyParameters };
+      const parameters = { ...localParameters, ...storyParameters };
+      const context = { name: storyName, parameters };
       const { jest } = parameters;
       const { ignore, ignoreDecorators } = jest || {};
 
@@ -58,10 +59,10 @@ exports.storiesOf = (groupName) => {
         it(storyName, async () => {
           const wrappingComponent = ignoreDecorators
             ? undefined
-            : ({ children }) => decorateStory(() => children, [...localDecorators, ...globalDecorators])({ parameters });
+            : ({ children }) => decorateStory(() => children, [...localDecorators, ...globalDecorators])(context);
 
           await act(async () => {
-            const { unmount, asFragment } = render(story(parameters), { wrapper: wrappingComponent });
+            const { unmount, asFragment } = render(story(context), { wrapper: wrappingComponent });
             // https://www.apollographql.com/docs/react/development-testing/testing/#testing-final-state
             // delays until the next "tick" of the event loop, and allows time
             // for that Promise returned from MockedProvider to be fulfilled


### PR DESCRIPTION
### Context

due to https://github.com/ornikar/shared-configs/pull/429, story name were not passed correctly

### Solution

create a context object, containing both parameters and name

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
