### PR TITLE
feat(eslint-config-node): add module-override [no issue]

### DIFF
--- a/@ornikar/eslint-config-node/README.md
+++ b/@ornikar/eslint-config-node/README.md
@@ -25,4 +25,18 @@ Also see:
 ### node with typescript
 
 1. `npm install --save-dev eslint @ornikar/eslint-config-typescript @ornikar/eslint-config-node`
-2. Add `"extends": ["@ornikar/eslint-config-typescript", "@ornikar/eslint-config-node""]` to your eslint config
+2. Add `"extends": ["@ornikar/eslint-config-typescript", "@ornikar/eslint-config-node"]` to your eslint config
+
+### module override
+
+```json
+{
+  "extends": ["@ornikar/eslint-config-typescript", "@ornikar/eslint-config-node"],
+  "overrides": [
+    {
+      "files": ["test-setup.js"],
+      "extends": ["@ornikar/eslint-config-node/module-override"]
+    }
+  ]
+}
+```

--- a/@ornikar/eslint-config-node/module-override.js
+++ b/@ornikar/eslint-config-node/module-override.js
@@ -1,8 +1,7 @@
 'use strict';
 
 module.exports = {
-  plugins: ['node'],
-  extends: ['plugin:node/recommended'],
+  extends: ['plugin:node/recommended-module'],
   rules: {
     // already checked by import plugin
     'node/no-unpublished-require': 'off',


### PR DESCRIPTION
### Context

In test-setup of components (https://github.com/ornikar/components/blob/master/test-setup.js) it is parsed by babel so it understands esm. We can't rename this file as mjs, because it doesnt currently works well with jest

### Solution

Add an override-module to be used in components (and other repo)

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
