### PR TITLE
feat: require node 12 fist lts [no issue]

### DIFF
--- a/@ornikar/browserslist-config/package.json
+++ b/@ornikar/browserslist-config/package.json
@@ -6,7 +6,7 @@
   "main": "degraded-support.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/commitlint-config/package.json
+++ b/@ornikar/commitlint-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-babel-use/package.json
+++ b/@ornikar/eslint-config-babel-use/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-babel/package.json
+++ b/@ornikar/eslint-config-babel/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-formatjs/package.json
+++ b/@ornikar/eslint-config-formatjs/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-node/package.json
+++ b/@ornikar/eslint-config-node/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-react/package.json
+++ b/@ornikar/eslint-config-react/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-typescript-react/package.json
+++ b/@ornikar/eslint-config-typescript-react/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config-typescript/package.json
+++ b/@ornikar/eslint-config-typescript/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/eslint-config/package.json
+++ b/@ornikar/eslint-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/intl-config/package.json
+++ b/@ornikar/intl-config/package.json
@@ -5,7 +5,7 @@
   "repository": "ornikar/shared-configs",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/jest-config-react/package.json
+++ b/@ornikar/jest-config-react/package.json
@@ -6,7 +6,7 @@
   "main": "jest-preset.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/jest-config/package.json
+++ b/@ornikar/jest-config/package.json
@@ -6,7 +6,7 @@
   "main": "jest-preset.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/lerna-config/package.json
+++ b/@ornikar/lerna-config/package.json
@@ -5,7 +5,7 @@
   "repository": "ornikar/shared-configs",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/postcss-config/package.json
+++ b/@ornikar/postcss-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/prettier-config/package.json
+++ b/@ornikar/prettier-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -3,7 +3,7 @@
   "version": "2.7.0",
   "description": "renovate shared config",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/repo-config-react/package.json
+++ b/@ornikar/repo-config-react/package.json
@@ -5,7 +5,7 @@
   "repository": "ornikar/shared-configs",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/repo-config/package.json
+++ b/@ornikar/repo-config/package.json
@@ -5,7 +5,7 @@
   "repository": "ornikar/shared-configs",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/rollup-config/package.json
+++ b/@ornikar/rollup-config/package.json
@@ -6,7 +6,7 @@
   "main": "createRollupConfig.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/@ornikar/stylelint-config/package.json
+++ b/@ornikar/stylelint-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "scripts": {
     "run-on-examples": "prettier --write --parser css ./examples/**/*.css && stylelint --fix ./examples"

--- a/@ornikar/webpack-config/package.json
+++ b/@ornikar/webpack-config/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "license": "ISC",
   "engines": {
-    "node": ">=12.16.1"
+    "node": ">=12.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "prettier": "./@ornikar/prettier-config",
   "engines": {
-    "node": ">=12.16.1",
+    "node": ">=12.13.0",
     "yarn": ">=1.10.1"
   },
   "eslintConfig": {


### PR DESCRIPTION
### Context

We don't really need 12.16, and one of our app is still in 12.14. We should update, but while we do,

### Solution

Require 12.13 instead, the first node 12 lts

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
