### PR TITLE
fix(rollup-config): postcss generate scoped name [no issue]

### DIFF
--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -58,7 +58,7 @@ const createBuildsForPackage = (packagesDir, packageName) => {
           include: /\.module\.css$/,
           extract: exportCss ? `${distPath}/styles.css` : true,
           modules: {
-            localIdentName: '[local]__[hash:base64:5]',
+            generateScopedName: `${packageName}_[local]_[hash:base64:5]`,
           },
           config: false,
           plugins: exportCss ? postcssConfig.plugins : false,


### PR DESCRIPTION
### Context

Before: `.styles-module_IconContainer__LmtH9`
After: `.kitt_IconContainer_LmtH9`

=> smaller and safer
I guess I missed this config when I upgraded a version of rollup postcss plugin ?

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
