### PR TITLE
fix(renovate-config): only auto approve patch and configs, fix schedules [no issue]

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -61,15 +61,25 @@
         },
         {
           "matchPackagePatterns": [
-            "^@ornikar/",
+            "^@ornikar/"
+          ],
+          "matchUpdateTypes": [
+            "patch"
+          ],
+          "labels": [
+            ":ok_hand: code/approved",
+            ":soon: automerge"
+          ]
+        },
+        {
+          "matchPackagePatterns": [
+            "^@ornikar/(.*)-config",
             "^@commitlint",
             "^eslint"
           ],
           "matchPackageNames": [
             "husky",
-            "lint-staged",
             "prettier",
-            "yarn-update-lock",
             "yarnhook"
           ],
           "matchUpdateTypes": [
@@ -83,7 +93,15 @@
           "rebaseStalePrs": false,
           "masterIssueApproval": false,
           "schedule": [
-            "at any time"
+            "after 10am and before 11am every weekday"
+          ]
+        },
+        {
+          "matchPackagePatterns": [
+            "^@ornikar/"
+          ],
+          "schedule": [
+            "after 10am and before 6pm every weekday"
           ]
         },
         {

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,12 @@
 {
-  "extends": ["config:js-lib", "@ornikar"]
+  "extends": ["config:js-lib", "@ornikar"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["lint-staged", "yarn-deduplicate"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "labels": [":ok_hand: code/approved", ":soon: automerge"],
+      "rebaseStalePrs": true,
+      "masterIssueApproval": false
+    }
+  ]
 }


### PR DESCRIPTION
Too much auto approve + fix schedules

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
