### PR TITLE
feat(renovate-confg): auto request reviews from frontend architects [no issue]

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -25,6 +25,9 @@
         ":soon: automerge"
       ],
       "rangeStrategy": "bump",
+      "reviewers": [
+        "team:frontend-architects"
+      ],
       "packageRules": [
         {
           "matchDepTypes": [
@@ -69,7 +72,8 @@
           "labels": [
             ":ok_hand: code/approved",
             ":soon: automerge"
-          ]
+          ],
+          "reviewers": []
         },
         {
           "matchPackagePatterns": [
@@ -90,6 +94,7 @@
             ":ok_hand: code/approved",
             ":soon: automerge"
           ],
+          "reviewers": [],
           "rebaseStalePrs": false,
           "masterIssueApproval": false,
           "schedule": [
@@ -115,6 +120,7 @@
             ":ok_hand: code/approved",
             ":soon: automerge"
           ],
+          "reviewers": [],
           "rebaseStalePrs": false,
           "masterIssueApproval": false,
           "schedule": [


### PR DESCRIPTION
https://ornikar.atlassian.net/wiki/spaces/A/pages/2067365972/2021-02-02#Discussions

I'm not 100% sure it will work, it might be `team:@ornikar/frontend-architects` ?

https://docs.renovatebot.com/configuration-options/#reviewers

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
