### PR TITLE
fix(renovate-config): open ornikar prs in schedule [no issue]

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -106,6 +106,8 @@
           "matchPackagePatterns": [
             "^@ornikar/"
           ],
+          "rebaseStalePrs": false,
+          "masterIssueApproval": false,
           "schedule": [
             "after 10am and before 6pm every weekday"
           ]


### PR DESCRIPTION
### Context

Current config:
```
{
          "matchPackagePatterns": [
            "^@ornikar/"
          ],
          "matchUpdateTypes": [
            "patch"
          ],
          "labels": [
            ":ok_hand: code/approved",
            ":soon: automerge"
          ],
          "reviewers": []
        },
        {
          "matchPackagePatterns": [
            "^@ornikar/(.*)-config",
            "^@commitlint",
            "^eslint"
          ],
          "matchPackageNames": [
            "husky",
            "prettier",
            "yarnhook"
          ],
          "matchUpdateTypes": [
            "minor",
            "patch"
          ],
          "labels": [
            ":ok_hand: code/approved",
            ":soon: automerge"
          ],
          "reviewers": [],
          "rebaseStalePrs": false,
          "masterIssueApproval": false,
          "schedule": [
            "after 10am and before 11am every weekday"
          ]
        },
        {
          "matchPackagePatterns": [
            "^@ornikar/"
          ],
          "schedule": [
            "after 10am and before 6pm every weekday"
          ]
        },
```

Schedule is defined for `@ornikar/*` packages but not `"masterIssueApproval": false`, we have to check in the renovate issue before renovate opens the PR, that's not what we want.




<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
