### PR TITLE
fix(lerna-config): eslintrc generator fix prettier config [no issue]

### DIFF
--- a/@ornikar/lerna-config/bin/generate-eslintrc-files.js
+++ b/@ornikar/lerna-config/bin/generate-eslintrc-files.js
@@ -11,7 +11,7 @@ const overrideConfig = (config, override) => {
   return { ...config, ...override };
 };
 
-const overrideAndWriteConfig = async (configPath, { override, callback, removeRules }) => {
+const overrideAndWriteConfig = async (configPath, prettierOptions, { override, callback, removeRules }) => {
   let config = await readJsonFile(configPath, {});
   config = overrideConfig(config, override);
 
@@ -29,11 +29,11 @@ const overrideAndWriteConfig = async (configPath, { override, callback, removeRu
     delete config.rules;
   }
 
-  await fs.writeFile(configPath, prettyEslintConfig(config));
+  await fs.writeFile(configPath, prettyEslintConfig(config, prettierOptions));
 };
 
-const generateAndWriteRootConfig = async (configPath) => {
-  await overrideAndWriteConfig(configPath, {
+const generateAndWriteRootConfig = async (configPath, prettierOptions) => {
+  await overrideAndWriteConfig(configPath, prettierOptions, {
     override: {
       root: true,
       extends: ['@ornikar/eslint-config/root'],
@@ -42,9 +42,9 @@ const generateAndWriteRootConfig = async (configPath) => {
   });
 };
 
-const generateAndWritePackageConfig = async (configPath, { packagePath, useRollupToBuild }) => {
+const generateAndWritePackageConfig = async (configPath, prettierOptions, { packagePath, useRollupToBuild }) => {
   if (!useRollupToBuild) {
-    await overrideAndWriteConfig(configPath, {
+    await overrideAndWriteConfig(configPath, prettierOptions, {
       override: {
         root: true,
         extends: ['@ornikar/eslint-config', '@ornikar/eslint-config/node'],
@@ -52,7 +52,7 @@ const generateAndWritePackageConfig = async (configPath, { packagePath, useRollu
       removeRules: ['import/no-extraneous-dependencies'],
     });
   } else {
-    await overrideAndWriteConfig(configPath, {
+    await overrideAndWriteConfig(configPath, prettierOptions, {
       override: {
         root: true,
 
@@ -90,12 +90,15 @@ const generateAndWritePackageConfig = async (configPath, { packagePath, useRollu
   const rootPath = path.resolve('.');
   const lernaProject = createLernaProject(rootPath);
   const lernaPackages = await getPackages(lernaProject);
+  const prettierConfig = lernaProject.manifest.get('prettier');
+  // eslint-disable-next-line import/no-dynamic-require, global-require
+  const prettierOptions = require(prettierConfig.startsWith('./') ? path.resolve(prettierConfig) : prettierConfig);
   const eslintRootConfigPath = `${rootPath}/.eslintrc.json`;
 
   const useRollupToBuild = lernaProject.manifest.devDependencies['@ornikar/rollup-config'] !== undefined;
 
   await Promise.all([
-    generateAndWriteRootConfig(eslintRootConfigPath),
+    generateAndWriteRootConfig(eslintRootConfigPath, prettierOptions),
 
     ...lernaProject.packageParentDirs.map((parentDir) =>
       Promise.all([
@@ -113,7 +116,7 @@ const generateAndWritePackageConfig = async (configPath, { packagePath, useRollu
       await Promise.all([
         useRollupToBuild ? fs.unlink(`${packagePath}/.eslintrc.json`).catch(() => {}) : undefined,
         fs.unlink(`${packagePath}/.eslintrc.js`).catch(() => {}),
-        generateAndWritePackageConfig(eslintSrcConfigPath, { packagePath, useRollupToBuild }),
+        generateAndWritePackageConfig(eslintSrcConfigPath, prettierOptions, { packagePath, useRollupToBuild }),
       ]);
     }),
   ]);


### PR DESCRIPTION
### Context

Fixes issues when eslintrc generator doesnt agree with repo prettier config

### Solution

Pass config to `prettyEslintConfig` so it use the same config of prettier everywhere

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
