### PR TITLE
feat(renovate-config): add missing eslint-config-formatjs [no issue]

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -144,6 +144,7 @@
           "matchPackageNames": [
             "@ornikar/eslint-config",
             "@ornikar/eslint-config-babel",
+            "@ornikar/eslint-config-formatjs",
             "@ornikar/eslint-config-node",
             "@ornikar/eslint-config-react",
             "@ornikar/eslint-config-typescript",


### PR DESCRIPTION
### Context

eslint-config-formatjs is missing in renovate config