### PR TITLE
refactor: eslint report unused disable directives ARCH-1184

### DIFF
--- a/@ornikar/jest-config/test-setup-after-env.js
+++ b/@ornikar/jest-config/test-setup-after-env.js
@@ -6,7 +6,6 @@
 
 // https://github.com/facebook/react/blob/master/scripts/jest/setupTests.js
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 const util = require('util');
 const chalk = require('chalk');
 

--- a/@ornikar/postcss-config/index.js
+++ b/@ornikar/postcss-config/index.js
@@ -1,4 +1,4 @@
-/* eslint-disable global-require, no-param-reassign */
+/* eslint-disable global-require */
 
 'use strict';
 

--- a/@ornikar/repo-config-react/createLintStagedConfig.js
+++ b/@ornikar/repo-config-react/createLintStagedConfig.js
@@ -9,7 +9,6 @@ const pkg = JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf-8'));
 module.exports = function createLintStagedConfig(options = {}) {
   const config = createBaseLintStagedConfig({ srcExtensions: ['js', 'mjs', 'ts', 'tsx'] });
 
-  // eslint-disable-next-line prefer-destructuring
   const srcDirectories = createBaseLintStagedConfig.getSrcDirectories();
 
   Object.assign(config, {

--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* eslint-disable complexity, import/no-dynamic-require */
+/* eslint-disable import/no-dynamic-require */
 
 const fs = require('fs');
 const path = require('path');
@@ -17,7 +17,7 @@ const extensions = ['.tsx', '.ts', '.js', '.jsx'];
 const browserOnlyExtensions = ['.css'];
 
 const createBuildsForPackage = (packagesDir, packageName, additionalPlugins = []) => {
-  // eslint-disable-next-line import/no-dynamic-require, global-require
+  // eslint-disable-next-line global-require
   const pkg = require(path.resolve(`./${packagesDir}/${packageName}/package.json`));
   const external = configExternalDependencies({
     devDependencies: { ...rootPkg.devDependencies, ...pkg.devDependencies },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "yarn run lint:prettier && yarn run lint:eslint",
     "lint:prettier": "prettier --check .",
-    "lint:eslint": "eslint --ext .js --fix .",
+    "lint:eslint": "eslint --ext .js --report-unused-disable-directives .",
     "release": "lerna publish --conventional-commits -m 'chore: release'"
   },
   "prettier": "./@ornikar/prettier-config",


### PR DESCRIPTION
### Context

enable use of `--report-unused-disable-directives` eslint option