### PR TITLE
feat(lerna-config): remove @ornikar/eslint-config-typescript when @ornikar/eslint-config-typescript-react is present [no issue]

### DIFF
--- a/@ornikar/lerna-config/bin/generate-eslintrc-files.js
+++ b/@ornikar/lerna-config/bin/generate-eslintrc-files.js
@@ -64,7 +64,11 @@ const generateAndWritePackageConfig = async (configPath, prettierOptions, { pack
       callback: (configParam) => {
         const config = { ...configParam };
         if (!config.extends) config.extends = [];
-        if (!config.extends.includes('@ornikar/eslint-config-typescript')) {
+        if (config.extends.includes('@ornikar/eslint-config-typescript-react')) {
+          if (config.extends.includes('@ornikar/eslint-config-typescript')) {
+            config.extends = config.extends.filter('@ornikar/eslint-config-typescript');
+          }
+        } else if (!config.extends.includes('@ornikar/eslint-config-typescript')) {
           config.extends = ['@ornikar/eslint-config-typescript', ...config.extends];
         }
         if (!config.extends.includes('@ornikar/eslint-config/rollup')) {

--- a/@ornikar/lerna-config/bin/generate-eslintrc-files.js
+++ b/@ornikar/lerna-config/bin/generate-eslintrc-files.js
@@ -66,7 +66,7 @@ const generateAndWritePackageConfig = async (configPath, prettierOptions, { pack
         if (!config.extends) config.extends = [];
         if (config.extends.includes('@ornikar/eslint-config-typescript-react')) {
           if (config.extends.includes('@ornikar/eslint-config-typescript')) {
-            config.extends = config.extends.filter('@ornikar/eslint-config-typescript');
+            config.extends = config.extends.filter(config => config !== '@ornikar/eslint-config-typescript');
           }
         } else if (!config.extends.includes('@ornikar/eslint-config-typescript')) {
           config.extends = ['@ornikar/eslint-config-typescript', ...config.extends];

--- a/@ornikar/lerna-config/bin/generate-eslintrc-files.js
+++ b/@ornikar/lerna-config/bin/generate-eslintrc-files.js
@@ -66,7 +66,7 @@ const generateAndWritePackageConfig = async (configPath, prettierOptions, { pack
         if (!config.extends) config.extends = [];
         if (config.extends.includes('@ornikar/eslint-config-typescript-react')) {
           if (config.extends.includes('@ornikar/eslint-config-typescript')) {
-            config.extends = config.extends.filter(config => config !== '@ornikar/eslint-config-typescript');
+            config.extends = config.extends.filter((c) => c !== '@ornikar/eslint-config-typescript');
           }
         } else if (!config.extends.includes('@ornikar/eslint-config-typescript')) {
           config.extends = ['@ornikar/eslint-config-typescript', ...config.extends];


### PR DESCRIPTION
BREAKING CHANGE: requires eslint 7

### Context

With the latest eslint-config-typescript with eslint 7, when eslint-config-typescript-react is used eslint-config-typescript also

### Solution

update lerna config to avoid requiring them both

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
