### PR TITLE
fix(rollup-config): use flatMap [no issue]

### DIFF
--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -165,5 +165,5 @@ module.exports = (packagesDir = '@ornikar') => {
         .readdirSync(path.resolve(`./${packagesDir}`))
         .filter((name) => name !== '.DS_Store' && !name.startsWith('.eslintrc'));
 
-  return packages.map((packageName) => createBuildsForPackage(packagesDir, packageName));
+  return packages.flatMap((packageName) => createBuildsForPackage(packagesDir, packageName));
 };


### PR DESCRIPTION
### Context

I made a mistake when I fixed the concat issue with eslint 7

### Solution

Use flatMap to flatten the map. Tested with kitt.