### PR TITLE
fix(repo-config-react): svgo config for react-native compatibility [no issue]

### DIFF
--- a/@ornikar/repo-config-react/.svgo.yml
+++ b/@ornikar/repo-config-react/.svgo.yml
@@ -8,3 +8,5 @@ plugins:
   # remove data-name
   - removeUnknownsAndDefaults:
       keepDataAttrs: false
+  - inlineStyles:
+      onlyMatchedOnce: false


### PR DESCRIPTION
### Context

### disable onlyMatchedOnce in inlineStyles :
It's the only thing that differs from our config of https://github.com/kristerkari/react-native-svg-transformer/blob/master/index.js#L51-L65
Having the same config avoids running svgo at each build.

https://github.com/svg/svgo/blob/master/plugins/inlineStyles.js#L24-L25

