### PR TITLE
fix(@ornikar/lerna-config): support private package with react [no issue]

### DIFF
--- a/@ornikar/lerna-config/bin/generate-tsconfig-files.js
+++ b/@ornikar/lerna-config/bin/generate-tsconfig-files.js
@@ -59,7 +59,10 @@ const { getPackages } = require('..');
         );
       });
 
-      const hasReact = pkg.peerDependencies && pkg.peerDependencies.react;
+      const hasReact =
+        (pkg.peerDependencies && pkg.peerDependencies.react) ||
+        (pkg.private && pkg.dependencies && pkg.dependencies.react);
+
       if (hasReact) {
         tsconfigContent.compilerOptions.jsx = 'preserve';
       }


### PR DESCRIPTION
private package are examples or apps. In that case, react is in dependencies, not peerDependencies.
