### PR TITLE
fix(repo-config): remove invalid husky peer dependency [no issue]

### DIFF
--- a/@ornikar/repo-config/package.json
+++ b/@ornikar/repo-config/package.json
@@ -10,9 +10,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
-    "husky": "^4.0.0"
-  },
   "bin": {
     "ornikar-repo-config-postinstall": "./bin/ornikar-repo-config-postinstall.js"
   },


### PR DESCRIPTION
husky is now installed via dependencies and should no longer be in peer dependency + it was an invalid version
