### PR TITLE
feat: drop timezone-mock in favor of env variable [no issue]

### DIFF
--- a/@ornikar/jest-config/global-mocks.js
+++ b/@ornikar/jest-config/global-mocks.js
@@ -1,15 +1,8 @@
 'use strict';
 
-// order is: mockdate, then timezone mock
-// requiring timezone mock sets its internal _Date, so date must be mocked before.
-// eslint-disable-next-line import/order
 const mockdate = require('mockdate');
 
 mockdate.set('2018-07-30T08:52:42.679Z');
-
-const timezoneMock = require('timezone-mock');
-
-timezoneMock.register('UTC');
 
 // Mock getFullYear
 Date.getFullYear = () => 2019;

--- a/@ornikar/jest-config/package.json
+++ b/@ornikar/jest-config/package.json
@@ -16,8 +16,7 @@
   },
   "dependencies": {
     "chalk": "^4.0.0",
-    "mockdate": "^3.0.2",
-    "timezone-mock": "^1.0.5"
+    "mockdate": "^3.0.2"
   },
   "peerDependencies": {
     "jest": ">= 24.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15543,11 +15543,6 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-timezone-mock@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/timezone-mock/-/timezone-mock-1.0.5.tgz#c8aad75a7f207141cf6471eb22f4c33bd4ebe294"
-  integrity sha512-SBhcSV4ArM7fEDalFWvvf/2ZZx5GVgnhHgjjYZ0xIp2qz3murj8hK3nUMI4mYcRGFnrQ0DDerjI6N/ie4rdVug==
-
 timm@^1.6.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/timm/-/timm-1.7.1.tgz#96bab60c7d45b5a10a8a4d0f0117c6b7e5aff76f"


### PR DESCRIPTION
### Context

timezone-mock can cause issues and we can still use if for specific tests when we need to change timezone.

Otherwise, it is safer and preferable to use TZ env variable 

```
  "test": "TZ='UTC' jest"
```