### PR TITLE
feat(lerna-config): support react 17 [no issue]

### DIFF
--- a/@ornikar/lerna-config/bin/generate-tsconfig-files.js
+++ b/@ornikar/lerna-config/bin/generate-tsconfig-files.js
@@ -64,7 +64,7 @@ const { getPackages } = require('..');
         (pkg.private && pkg.dependencies && pkg.dependencies.react);
 
       if (hasReact) {
-        tsconfigContent.compilerOptions.jsx = 'preserve';
+        tsconfigContent.compilerOptions.jsx = 'react-jsx';
       }
 
       if (dependencies.length > 0) {


### PR DESCRIPTION
react 17 adds a new jsx transformer that makes importing React useless.