### PR TITLE
fix(rollup-config): do not build private packages [no issue]

### DIFF
--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -19,6 +19,7 @@ const browserOnlyExtensions = ['.css'];
 const createBuildsForPackage = (packagesDir, packageName, additionalPlugins = []) => {
   // eslint-disable-next-line global-require
   const pkg = require(path.resolve(`./${packagesDir}/${packageName}/package.json`));
+  if (pkg.private) return [];
   const external = configExternalDependencies({
     devDependencies: { ...rootPkg.devDependencies, ...pkg.devDependencies },
     dependencies: { ...rootPkg.dependencies, ...pkg.dependencies },


### PR DESCRIPTION
### Context

Support for examples to be in monorepo librairies, packages that don't need to be built

Related PR: https://github.com/ornikar/shared-configs/pull/542