### PR TITLE
feat: add waitFor in stories mock [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
+++ b/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
@@ -2,7 +2,7 @@
 
 'use strict';
 
-const { render } = require('@testing-library/react-native');
+const { render, waitFor } = require('@testing-library/react-native');
 const React = require('react');
 
 const decorateStory = (storyFn, decorators) =>
@@ -51,7 +51,7 @@ exports.storiesOf = (groupName) => {
       const parameters = { ...localParameters, ...storyParameters };
       const context = { name: storyName, parameters };
       const { jest } = parameters;
-      const { ignore, ignoreDecorators, createBeforeAfterEachCallbacks } = jest || {};
+      const { ignore, ignoreDecorators, createBeforeAfterEachCallbacks, waitFor: waitForExpectation } = jest || {};
 
       if (ignore) {
         test.skip(storyName, () => {});
@@ -65,12 +65,13 @@ exports.storiesOf = (groupName) => {
           if (after) afterEach(after);
         }
 
-        it(storyName, () => {
+        it(storyName, async () => {
           const WrappingComponent = ignoreDecorators
             ? undefined
             : ({ children }) => decorateStory(() => children, [...localDecorators, ...globalDecorators])(context);
 
           const component = render(React.createElement(WrappingComponent, { children: story(context) }));
+          if (waitForExpectation) await waitFor(waitForExpectation);
           expect(component.toJSON()).toMatchSnapshot();
         });
       });

--- a/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
+++ b/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
@@ -70,9 +70,9 @@ exports.storiesOf = (groupName) => {
             ? undefined
             : ({ children }) => decorateStory(() => children, [...localDecorators, ...globalDecorators])(context);
 
-          const component = render(React.createElement(WrappingComponent, { children: story(context) }));
-          if (waitForExpectation) await waitFor(waitForExpectation);
-          expect(component.toJSON()).toMatchSnapshot();
+          const rtlApi = render(React.createElement(WrappingComponent, { children: story(context) }));
+          if (waitForExpectation) await waitFor(() => waitForExpectation(rtlApi, expect));
+          expect(rtlApi.toJSON()).toMatchSnapshot();
         });
       });
 

--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -69,11 +69,12 @@ exports.storiesOf = (groupName) => {
             : ({ children }) => decorateStory(() => children, [...localDecorators, ...globalDecorators])(context);
 
           await act(async () => {
-            const { unmount, asFragment } = render(story(context), { wrapper: wrappingComponent });
+            const rtlApi = render(story(context), { wrapper: wrappingComponent });
+            const { unmount, asFragment } = rtlApi;
             // https://www.apollographql.com/docs/react/development-testing/testing/#testing-final-state
             // delays until the next "tick" of the event loop, and allows time
             // for that Promise returned from MockedProvider to be fulfilled
-            await (waitForExpectation ? waitFor(waitForExpectation) : wait(0));
+            await (waitForExpectation ? waitFor(() => waitForExpectation(rtlApi, expect)) : wait(0));
             expect(asFragment()).toMatchSnapshot();
             unmount();
           });


### PR DESCRIPTION
### Context

We can now wait for something before snapshoting a story

Example:
![image](https://user-images.githubusercontent.com/302891/143877693-cc555dd7-031c-4c66-b9df-31909f7a37b1.png)
