### PR TITLE
fix(jest-config): support next-gen jest-circus runner [no issue]

### DIFF
--- a/@ornikar/jest-config/package.json
+++ b/@ornikar/jest-config/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "chalk": "^4.0.0",
+    "jest-fail-on-console": "^2.1.1",
     "mockdate": "^3.0.2"
   },
   "peerDependencies": {

--- a/@ornikar/jest-config/test-setup-after-env.js
+++ b/@ornikar/jest-config/test-setup-after-env.js
@@ -1,15 +1,12 @@
 /* eslint-disable no-console */
+/* eslint-env jest */
 
 'use strict';
-
-/* global jasmine */
 
 // https://github.com/facebook/react/blob/master/scripts/jest/setupTests.js
 
 const util = require('util');
 const chalk = require('chalk');
-
-const env = jasmine.getEnv();
 
 // Deprecated lifecycle methods are forbidden in our eslint config. This means any related warning is due to a dependency and can be ignored in tests.
 const deprecatedReactLifeCycleMethods = [
@@ -40,11 +37,11 @@ const deprecatedReactLifeCycleMethods = [
 
   console[methodName] = newMethod;
 
-  env.beforeEach(() => {
+  beforeEach(() => {
     unexpectedConsoleCallStacks.length = 0;
   });
 
-  env.afterEach(() => {
+  afterEach(() => {
     if (console[methodName] !== newMethod) {
       throw new Error(`Test did not tear down console.${methodName} mock properly.`);
     }

--- a/@ornikar/jest-config/test-setup-after-env.js
+++ b/@ornikar/jest-config/test-setup-after-env.js
@@ -1,12 +1,10 @@
-/* eslint-disable no-console */
 /* eslint-env jest */
 
 'use strict';
 
 // https://github.com/facebook/react/blob/master/scripts/jest/setupTests.js
 
-const util = require('util');
-const chalk = require('chalk');
+const failOnConsole = require('jest-fail-on-console');
 
 // Deprecated lifecycle methods are forbidden in our eslint config. This means any related warning is due to a dependency and can be ignored in tests.
 const deprecatedReactLifeCycleMethods = [
@@ -16,53 +14,10 @@ const deprecatedReactLifeCycleMethods = [
   'componentWillReceiveProps',
 ];
 
-['error', 'warn'].forEach((methodName) => {
-  const unexpectedConsoleCallStacks = [];
-  const newMethod = function (format, ...args) {
-    if (typeof format === 'string') {
-      if (
-        deprecatedReactLifeCycleMethods.some((lifecycleMethod) =>
-          format.includes(`${lifecycleMethod} has been renamed, and is not recommended for use.`),
-        )
-      ) {
-        return;
-      }
-    }
-    // Capture the call stack now so we can warn about it later.
-    // The call stack has helpful information for the test author.
-    // Don't throw yet though b'c it might be accidentally caught and suppressed.
-    const errorStack = new Error('test-setup-after-env').stack;
-    unexpectedConsoleCallStacks.push([errorStack.slice(errorStack.indexOf('\n') + 1), util.format(format, ...args)]);
-  };
-
-  console[methodName] = newMethod;
-
-  beforeEach(() => {
-    unexpectedConsoleCallStacks.length = 0;
-  });
-
-  afterEach(() => {
-    if (console[methodName] !== newMethod) {
-      throw new Error(`Test did not tear down console.${methodName} mock properly.`);
-    }
-
-    if (unexpectedConsoleCallStacks.length > 0) {
-      const messages = unexpectedConsoleCallStacks.map(
-        ([stack, message]) =>
-          `${chalk.red(message)}\n` +
-          `${stack
-            .split('\n')
-            .map((line) => chalk.gray(line))
-            .join('\n')}`,
-      );
-
-      const message = `Expected test not to call ${chalk.bold(
-        `console.${methodName}()`,
-      )}.\n\nIf the warning is expected, test for it explicitly.`;
-
-      // throw messages;
-
-      throw new Error(`${message}\n\n${messages.join('\n\n')}`);
-    }
-  });
+failOnConsole({
+  silenceMessage: (message) => {
+    return deprecatedReactLifeCycleMethods.some((lifecycleMethod) =>
+      message.includes(`${lifecycleMethod} has been renamed, and is not recommended for use.`),
+    );
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7306,6 +7306,13 @@ jest-expo@44.0.1:
     lodash "^4.17.19"
     react-test-renderer "~17.0.1"
 
+jest-fail-on-console@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/jest-fail-on-console/-/jest-fail-on-console-2.1.1.tgz#3e434a6f5f8183b6eac87ed0f2f1b804d7e06efc"
+  integrity sha512-oKUtNAJy2r2q4RaOrtGsqysOEPX7CPzS+ifmDjbQzl3/uysZ0+Ni+ZGQ/ERDHhNUemlo3w0KcbKOlLJwRPmnmA==
+  dependencies:
+    chalk "^4.1.0"
+
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"


### PR DESCRIPTION
[jest-circus](), the default for jest 27 but already used in creact-react-app (https://github.com/facebook/create-react-app/blob/54ad467598214927bab38e163ff520063c3a00df/packages/react-scripts/scripts/utils/createJestConfig.js#L42), doesnt support jasmine api anymore
I tried fixing it, but it's even better to use a lib that does that.