### PR TITLE
fix(repo-config): run yarn dedupe fewer, like renovate does [no issue]

### DIFF
--- a/@ornikar/repo-config/createLintStagedConfig.js
+++ b/@ornikar/repo-config/createLintStagedConfig.js
@@ -27,6 +27,7 @@ module.exports = function createLintStagedConfig(options = {}) {
       const packagejsonFilenames = filenames.filter((filename) => filename.endsWith('.json'));
       return [
         'yarn --prefer-offline',
+        'yarn-deduplicate -s fewer',
         'yarn-deduplicate',
         'yarn --prefer-offline',
         packagejsonFilenames.length === 0 ? undefined : `prettier --write ${packagejsonFilenames.join(' ')}`,


### PR DESCRIPTION
### Context

Like renovate ( https://github.com/ornikar/shared-configs/blob/master/@ornikar/renovate-config/package.json#L20-L22 ) and what we do manually ( https://ornikar.atlassian.net/wiki/spaces/MB2C/pages/2949087586/Version+dependencies+management+-+WIP )

