### PR TITLE
fix(lerna-config): allow apps and examples to extends from something else [no issue]

### DIFF
--- a/@ornikar/lerna-config/bin/generate-tsconfig-files.js
+++ b/@ornikar/lerna-config/bin/generate-tsconfig-files.js
@@ -22,8 +22,8 @@ const { getGraphPackages } = require('..');
       const tsconfigCurrentContent = pkg.private ? JSON.parse(await fs.readFile(tsconfigPath)) : {};
 
       const tsconfigContent = {
-        ...tsconfigCurrentContent,
         extends: '../../tsconfig.base.json',
+        ...tsconfigCurrentContent,
         compilerOptions: {
           rootDirs: ['src'],
           baseUrl: './src',


### PR DESCRIPTION
for example, expo/tsconfig.base for expo app
