### PR TITLE
fix(renovate-confg): change eslint configs group as no longer in shared-configs [no issue]

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -141,7 +141,7 @@
           "masterIssueApproval": true
         },
         {
-          "groupName": "Eslint Ornikar Shared Configs",
+          "groupName": "Ornikar Eslint Configs",
           "matchPackageNames": [
             "@ornikar/eslint-config",
             "@ornikar/eslint-config-babel",


### PR DESCRIPTION
ornikar eslint configs used to be in shared-configs, this is no longer the case and title is misleading
