### PR TITLE
fix(jest-config-react-native): use wrapper option in storybook mock [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
+++ b/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
@@ -70,7 +70,7 @@ exports.storiesOf = (groupName) => {
             ? undefined
             : ({ children }) => decorateStory(() => children, [...localDecorators, ...globalDecorators])(context);
 
-          const rtlApi = render(React.createElement(WrappingComponent, { children: story(context) }));
+          const rtlApi = render(story(context), { wrapper: WrappingComponent });
           if (waitForExpectation) await waitFor(() => waitForExpectation(rtlApi, expect));
           expect(rtlApi.toJSON()).toMatchSnapshot();
         });


### PR DESCRIPTION
### Context

`wrapper` doesn't render what is wrapped in the snapshot