### PR TITLE
chore: fix eslint config [no issue]

### DIFF
--- a/@ornikar/intl-config/.eslintrc.json
+++ b/@ornikar/intl-config/.eslintrc.json
@@ -1,4 +1,4 @@
 {
   "root": true,
-  "extends": ["@ornikar/eslint-config", "@ornikar/eslint-config/node"]
+  "extends": ["@ornikar/eslint-config/node"]
 }

--- a/@ornikar/renovate-config/.eslintrc.json
+++ b/@ornikar/renovate-config/.eslintrc.json
@@ -1,4 +1,4 @@
 {
   "root": true,
-  "extends": ["@ornikar/eslint-config", "@ornikar/eslint-config/node"]
+  "extends": ["@ornikar/eslint-config/node"]
 }

--- a/@ornikar/repo-config-react/.eslintrc.json
+++ b/@ornikar/repo-config-react/.eslintrc.json
@@ -1,4 +1,4 @@
 {
   "root": true,
-  "extends": ["@ornikar/eslint-config", "@ornikar/eslint-config/node"]
+  "extends": ["@ornikar/eslint-config/node"]
 }

--- a/@ornikar/repo-config/.eslintrc.json
+++ b/@ornikar/repo-config/.eslintrc.json
@@ -1,4 +1,4 @@
 {
   "root": true,
-  "extends": ["@ornikar/eslint-config", "@ornikar/eslint-config/node"]
+  "extends": ["@ornikar/eslint-config/node"]
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "yarn run lint:prettier && yarn run lint:eslint && yarn run lint:css",
     "lint:prettier": "prettier --check .",
-    "lint:eslint": "eslint --ext .js --report-unused-disable-directives .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:css": "yarn --cwd @ornikar/stylelint-config lint-tests",
     "release": "lerna publish --conventional-commits -m 'chore: release'",
     "postinstall": "./@ornikar/repo-config/bin/ornikar-repo-config-postinstall.js"


### PR DESCRIPTION
- fix legacy eslint-config-node which was replaced some time ago by eslint-config/node
- remove ext in eslint command which is no longer necessary with eslint 7