### PR TITLE
fix(lerna-config): dont add dep path in rootDirs [no issue]

### DIFF
--- a/@ornikar/lerna-config/bin/generate-tsconfig-files.js
+++ b/@ornikar/lerna-config/bin/generate-tsconfig-files.js
@@ -88,13 +88,11 @@ const { getGraphPackages } = require('..');
           dependencies.forEach((pkgDep) => {
             const depPath = `../../../${pkgDep.name}/src`;
             tsconfigContent.compilerOptions.paths[pkgDep.name] = [`${depPath}/index.ts`];
-            tsconfigContent.compilerOptions.rootDirs.push(depPath);
           });
         }
         tsconfigBuildContent.references = dependencies.map((pkgDep) => ({
           path: `../../${pkgDep.name}/tsconfig.build.json`,
         }));
-        tsconfigBuildContent.compilerOptions.rootDirs = ['src'];
         tsconfigBuildContent.compilerOptions.paths = {};
       }
 


### PR DESCRIPTION
a thing from my past
setting rootDirs is not necessary at all

related to https://github.com/christophehurpeau/pob/commit/11cea8d6fed56ad4405044e10f906d08e8ca3c02#diff-ce4ff68de1e531b53ccf71332f8bd1368367c28f13147f85e27a400f4c342c50