### PR TITLE
fix(lerna-config): support empty entries in generators [no issue]

### DIFF
--- a/@ornikar/lerna-config/bin/generate-eslintrc-files.js
+++ b/@ornikar/lerna-config/bin/generate-eslintrc-files.js
@@ -112,6 +112,9 @@ const generateAndWritePackageConfig = async (configPath, prettierOptions, { pack
     ),
     ...lernaPackages.map(async (pkg) => {
       if (pkg.private) return;
+      const ornikarConfig = pkg.get('ornikar');
+      const emptyEntries = ornikarConfig && ornikarConfig.entries ? ornikarConfig.entries.length === 0 : false;
+
       const packagePath = path.relative(rootPath, pkg.location);
       const eslintSrcConfigPath = useRollupToBuild
         ? `${packagePath}/src/.eslintrc.json`
@@ -120,7 +123,9 @@ const generateAndWritePackageConfig = async (configPath, prettierOptions, { pack
       await Promise.all([
         useRollupToBuild ? fs.unlink(`${packagePath}/.eslintrc.json`).catch(() => {}) : undefined,
         fs.unlink(`${packagePath}/.eslintrc.js`).catch(() => {}),
-        generateAndWritePackageConfig(eslintSrcConfigPath, prettierOptions, { packagePath, useRollupToBuild }),
+        emptyEntries
+          ? fs.unlink(eslintSrcConfigPath).catch(() => {})
+          : generateAndWritePackageConfig(eslintSrcConfigPath, prettierOptions, { packagePath, useRollupToBuild }),
       ]);
     }),
   ]);


### PR DESCRIPTION
### Context

We don't want tsconfig nor eslint config files in packages that don't have source files
Example:
- https://github.com/ornikar/kitt/tree/master/%40ornikar/geomanist-font
- https://github.com/ornikar/shared-apps/tree/main/%40ornikar/webapp-tools

Tested on shared-apps