### PR TITLE
feat(jest-config-react): remove random wait, add global addParameters [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
+++ b/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
@@ -77,7 +77,7 @@ exports.storiesOf = (groupName) => {
             : ({ children }) => decorateStory(() => children, [...localDecorators, ...globalDecorators])(context);
 
           const rtlApi = render(story(context), { wrapper: WrappingComponent });
-          if (waitForExpectation) await waitFor(() => waitForExpectation(rtlApi, expect));
+          if (waitForExpectation) await waitFor(() => waitForExpectation(rtlApi, expect, { parameters }));
           expect(rtlApi.toJSON()).toMatchSnapshot();
         });
       });

--- a/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
+++ b/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
@@ -31,10 +31,16 @@ const decorateStory = (storyFn, decorators) =>
 exports.decorateStory = decorateStory;
 
 const globalDecorators = [];
+const globalParameters = {};
 
 // Mocked version of `import { addDecorator } from '@storybook/react-native'`.
 exports.addDecorator = (decorator) => {
   globalDecorators.push(decorator);
+};
+
+// Mocked version of `import { addParameters } from '@storybook/react-native'`.
+exports.addParameters = (parameters) => {
+  Object.assign(globalParameters, parameters);
 };
 
 // Mocked version of `import { action } from '@storybook/react-native'`.
@@ -48,7 +54,7 @@ exports.storiesOf = (groupName) => {
   // Mocked API to generate tests from & snapshot stories.
   const api = {
     add(storyName, story, storyParameters = {}) {
-      const parameters = { ...localParameters, ...storyParameters };
+      const parameters = { ...globalParameters, ...localParameters, ...storyParameters };
       const context = { name: storyName, parameters };
       const { jest } = parameters;
       const { ignore, ignoreDecorators, createBeforeAfterEachCallbacks, waitFor: waitForExpectation } = jest || {};

--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -76,7 +76,7 @@ exports.storiesOf = (groupName) => {
             const rtlApi = render(story(context), { wrapper: wrappingComponent });
             const { unmount, asFragment } = rtlApi;
             if (waitForExpectation) {
-              await waitFor(() => waitForExpectation(rtlApi, expect));
+              await waitFor(() => waitForExpectation(rtlApi, expect, { parameters }));
             }
             expect(asFragment()).toMatchSnapshot();
             unmount();


### PR DESCRIPTION
### Context

While updating apollo in a webapp, I found the wait(0) didn't work anymore and `wait(0).then(() => wait(0))` worked.
However, it seemed stranged to make this change in this shared config repository, specially when not all repo uses apollo

### Solution

let the app add parameters globally via test-setup so that `wait(0)` can be configured there, and even add conditions based on parameters passed.

Example

> test-setup.ts

```
addParameters({
  jest: {
    waitFor: () => wait(0).then(() => wait(0)),
  },
});
```