### PR TITLE
feat(rollup-config): add platform os support with specific builds [no issue]

### DIFF
--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -33,7 +33,7 @@ const createBuildsForPackage = (packagesDir, packageName, additionalPlugins = []
   const distPath = `${packagesDir}/${packageName}/dist`;
   const inputBaseDir = `./${packagesDir}/${packageName}/src/`;
 
-  const createBuild = (entryName, target, version, formats, { exportCss, targetExtension } = {}) => {
+  const createBuild = (entryName, target, version, formats, { exportCss, platformOS } = {}) => {
     const preferConst = !(target === 'browser' && version !== 'modern');
 
     const inputExt = extensions.find((ext) => fs.existsSync(path.resolve(`${inputBaseDir}${entryName}${ext}`)));
@@ -43,9 +43,7 @@ const createBuildsForPackage = (packagesDir, packageName, additionalPlugins = []
     return {
       input: `${inputBaseDir}${entryName}${inputExt}`,
       output: formats.map((format) => ({
-        file: `${distPath}/${entryName}-${target}-${version}.${format}${
-          targetExtension ? `.${targetExtension}` : ''
-        }.js`,
+        file: `${distPath}/${entryName}-${target}-${version}.${format}${platformOS ? `.${platformOS}` : ''}.js`,
         format,
         sourcemap: true,
         exports: 'named',
@@ -129,6 +127,7 @@ const createBuildsForPackage = (packagesDir, packageName, additionalPlugins = []
                 ],
               },
             ],
+            [require.resolve('babel-plugin-react-native'), { OS: platformOS }],
             require.resolve('babel-plugin-minify-dead-code-elimination'),
             require.resolve('babel-plugin-discard-module-references'),
           ].filter(Boolean),
@@ -140,7 +139,7 @@ const createBuildsForPackage = (packagesDir, packageName, additionalPlugins = []
           },
         }),
         resolve({
-          extensions: targetExtension ? extensions.flatMap((ext) => [`.${targetExtension}${ext}`, ext]) : extensions,
+          extensions: platformOS ? extensions.flatMap((ext) => [`.${platformOS}${ext}`, ext]) : extensions,
           modulesOnly: true,
           jail: `${resolvedPackagePath}/src`,
           rootDir: resolvedPackagePath,
@@ -161,9 +160,9 @@ const createBuildsForPackage = (packagesDir, packageName, additionalPlugins = []
       createBuild(entryName, 'browser', 'all', ['es'], { exportCss: !hasPeerDependencyReactNative }),
       ...(hasPeerDependencyReactNative
         ? [
-            createBuild(entryName, 'browser', 'all', ['es'], { targetExtension: 'web', exportCss: true }),
-            createBuild(entryName, 'browser', 'all', ['es'], { targetExtension: 'ios' }),
-            createBuild(entryName, 'browser', 'all', ['es'], { targetExtension: 'android' }),
+            createBuild(entryName, 'browser', 'all', ['es'], { platformOS: 'web', exportCss: true }),
+            createBuild(entryName, 'browser', 'all', ['es'], { platformOS: 'ios' }),
+            createBuild(entryName, 'browser', 'all', ['es'], { platformOS: 'android' }),
           ]
         : []),
     ].filter(Boolean),

--- a/@ornikar/rollup-config/package.json
+++ b/@ornikar/rollup-config/package.json
@@ -22,6 +22,7 @@
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@rollup/plugin-replace": "^3.0.0",
+    "babel-plugin-react-native": "^1.0.0",
     "babel-plugin-discard-module-references": "^1.1.2",
     "babel-plugin-minify-dead-code-elimination": "^0.5.1",
     "babel-plugin-minify-replace": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3376,6 +3376,11 @@ babel-plugin-react-intl@^7.0.0:
     intl-messageformat-parser "^5.0.0"
     schema-utils "^2.2.0"
 
+babel-plugin-react-native@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-native/-/babel-plugin-react-native-1.0.0.tgz#395b7cdc0ac2b0f1f817cfce1f385197eb24d426"
+  integrity sha512-X1j/pjxd15uJkjACzVj6k8oSp4AU5GfgTAqMDGo1gUIDHG/CB4gfceidRhdX4NgTBsjiEYlM2aVfWYuH8FvXAA==
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"


### PR DESCRIPTION
### Context

Building libs for react-native requires to target specific extensions and should tree shake using Platform.OS

### Solution

Add plugin babel-plugin-react-native