### PR TITLE
fix(rollup-config): fix `!__DEV__` [no issue]

### DIFF
--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -147,7 +147,7 @@ const createBuildsForPackage = (packagesDir, packageName, additionalPlugins = []
         replace({
           preventAssignment: true,
           values: {
-            __DEV__: 'process.env.NODE_ENV !== "production"',
+            __DEV__: '(process.env.NODE_ENV !== "production")',
           },
         }),
         resolve({


### PR DESCRIPTION
### Context

`!__DEV__` is currently replaced by rollup to `!process.env.NODE_ENV !== "production"`

### Solution

What we really want is `!(process.env.NODE_ENV !== "production")`
We should probably use babel to replace this as it should be more safer, but this is for another PR

Related:
https://github.com/christophehurpeau/pob/commit/1d9296dd658ae741337302eefde237d402ee35bd
https://github.com/christophehurpeau/pob/commit/1dc4aa94b86546497249b725b0a75ce8d2f352a3