### PR TITLE
fix(lerna-config): allow library to self import [no issue]

### DIFF
--- a/@ornikar/lerna-config/bin/generate-tsconfig-files.js
+++ b/@ornikar/lerna-config/bin/generate-tsconfig-files.js
@@ -45,13 +45,6 @@ const { getGraphPackages } = require('..');
         include: tsconfigCurrentContent.include || ['src', '../../typings'],
       };
 
-      if (!pkg.private) {
-        // react-scripts doesn't like paths
-        tsconfigContent.compilerOptions.paths = {
-          [pkg.name]: ['./index.ts'],
-        };
-      }
-
       const tsconfigBuildContent = {
         extends: './tsconfig.json',
         compilerOptions: {
@@ -78,6 +71,16 @@ const { getGraphPackages } = require('..');
           '**/stories-list.ts',
         ],
       };
+
+      // react-scripts doesn't like paths
+      if (!pkg.private) {
+        tsconfigContent.compilerOptions.paths = {
+          [pkg.name]: ['./index.ts'],
+        };
+        tsconfigBuildContent.compilerOptions.paths = {
+          [pkg.name]: ['./index.ts'],
+        };
+      }
 
       const dependencies = packages.filter((lernaPkg) => {
         if (lernaPkg.name === pkg.name) return false;


### PR DESCRIPTION
### Context

This pattern can be used in tests/stories

<img width="657" alt="image" src="https://user-images.githubusercontent.com/302891/146783188-582987bf-4881-450e-8ad9-0c8fc4acc2c5.png">


### Solution

Add self to paths for tsconfig.build.json