### PR TITLE
feat(jest-config): set timezone to utc in config [no issue]

### DIFF
--- a/@ornikar/jest-config/jest-global-setup.ts
+++ b/@ornikar/jest-config/jest-global-setup.ts
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = () => {
+  process.env.TZ = 'UTC';
+};

--- a/@ornikar/jest-config/jest-preset.js
+++ b/@ornikar/jest-config/jest-preset.js
@@ -32,4 +32,5 @@ module.exports = {
     // project setup should always be placed last.
     '<rootDir>/test-setup.js',
   ],
+  globalSetup: './jest-global-setup.js',
 };


### PR DESCRIPTION
### Context

This pr sets the timezone used in tests in jest config. This is useful since tests may fail depending on the timezone of the machine where they are executed if the timezone is not set beforehand.
<!-- Explain here why this PR is needed -->

### Solution

We use a globalSetup file to mock process.env.TZ to utc timezone
<!-- Explain here the solution you chose for this -->

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
