### PR TITLE
feat(jest-config-react): add styled-components module name mapper [no issue]

### DIFF
--- a/@ornikar/jest-config-react/jest-preset.js
+++ b/@ornikar/jest-config-react/jest-preset.js
@@ -25,6 +25,7 @@ module.exports = {
   transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$', '^.+\\.css$'],
   moduleNameMapper: {
     '\\.css$': 'identity-obj-proxy',
+    '^styled-components$': 'styled-components/native',
     '@storybook/react$': require.resolve('./__mocks__/@storybook/react'),
     '@storybook/addon-knobs': require.resolve('./__mocks__/@storybook/addon-knobs'),
     'storybook-react-router': require.resolve('./__mocks__/storybook-react-router'),


### PR DESCRIPTION
now that we need to use web version of styled-components, we need to use the native version in jest (for metro, it's automatic)