### PR TITLE
feat(jest-config-react): mock @storybook/react-native [no issue]

### DIFF
--- a/@ornikar/jest-config-react/jest-preset.js
+++ b/@ornikar/jest-config-react/jest-preset.js
@@ -27,6 +27,7 @@ module.exports = {
     '\\.css$': 'identity-obj-proxy',
     '^styled-components$': 'styled-components/native',
     '@storybook/react$': require.resolve('./__mocks__/@storybook/react'),
+    '@storybook/react-native$': require.resolve('./__mocks__/@storybook/react'),
     '@storybook/addon-knobs': require.resolve('./__mocks__/@storybook/addon-knobs'),
     'storybook-react-router': require.resolve('./__mocks__/storybook-react-router'),
   },


### PR DESCRIPTION
### Context
In monorepos with web and native code, we want to generate both native and web snapshots from native stories wo we need to mock storybook/react-native in the same way that storybook/react is mocked
<!-- Explain here why this PR is needed -->

### Solution

We use modulenamemapper in jest config to map @storybook/react-native to the mock implem of storybook/react
<!-- Explain here the solution you chose for this -->

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
