### PR TITLE
feat(jest-config-react-native): support svg with svgr named loader CME-229

### DIFF
--- a/@ornikar/jest-config-react-native/jest-preset.js
+++ b/@ornikar/jest-config-react-native/jest-preset.js
@@ -31,6 +31,8 @@ module.exports = {
         return [key, value];
       }),
     ),
+    // legacy support, use { ReactComponent } from .svg instead.
+    '\\.inline\\.svg$': '@ornikar/jest-config-react-native/svg-transformer-inline',
     '\\.svg$': '@ornikar/jest-config-react-native/svg-transformer',
   },
 };

--- a/@ornikar/jest-config-react-native/svg-transformer-inline.js
+++ b/@ornikar/jest-config-react-native/svg-transformer-inline.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('jest-svg-transformer');

--- a/@ornikar/jest-config-react-native/svg-transformer.js
+++ b/@ornikar/jest-config-react-native/svg-transformer.js
@@ -9,7 +9,7 @@ exports.process = (src, filepath) => {
     `module.exports = new Proxy({}, {
     get: function getter(target, key) {
       if (key === '__esModule') {
-        return false;
+        return true;
       }
       if (key === 'default') {
         return $1.name;

--- a/@ornikar/jest-config-react-native/svg-transformer.js
+++ b/@ornikar/jest-config-react-native/svg-transformer.js
@@ -1,3 +1,24 @@
 'use strict';
 
-module.exports = require('jest-svg-transformer');
+const { process } = require('jest-svg-transformer');
+
+exports.process = (src, filepath) => {
+  const content = process(src, filepath);
+  return content.replace(
+    /module.exports = (.*);/,
+    `module.exports = new Proxy({}, {
+    get: function getter(target, key) {
+      if (key === '__esModule') {
+        return false;
+      }
+      if (key === 'default') {
+        return $1.name;
+      }
+      if (key === 'ReactComponent') {
+        return $1;
+      }
+      throw new Error('Invalid key for svg-transformer jest mock: ' + key);
+    }
+  });`,
+  );
+};


### PR DESCRIPTION
### Context

librairies and apps currently doesnt have the same loader for svg.
- webpack libraries (kitt/components): svg-react-loader
- rollup librairies: babel-plugin-inline-react-svg
- webpack with create-react-app: @svgr/webpack
- metro: @svgr/core via @ornikar/react-native-svg-transformer

### Solution

- use `exportType: name` config for svgr in `@ornikar/react-native-svg-transformer` to support app svg import format (commit: https://github.com/ornikar/react-native-svg-transformer/commit/9aefd6285f3673c902f78a73bf7a0e0f530429fa)
- configure a transformer in jest-config-react-native preset to support the new format while still having a fallback for libaries. Apps like instructors-app will need to make changes to work, so this is a breaking change.

### Goal 

We should use svgr everywhere in the same way: webpack config for libraries and rollup config should change.

