### PR TITLE
feat: add storybook react module mapper in jest react native preset [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/jest-preset.js
+++ b/@ornikar/jest-config-react-native/jest-preset.js
@@ -22,6 +22,8 @@ module.exports = {
     '^@storybook/addon-actions$': require.resolve('./__mocks__/@storybook/addon-actions.js'),
     '@storybook/react-native$': require.resolve('./__mocks__/@storybook/react-native.jsx'),
     '^@storybook/react-native$': require.resolve('./__mocks__/@storybook/react-native.jsx'),
+    '@storybook/react$': require.resolve('./__mocks__/@storybook/react-native.jsx'),
+    '^@storybook/react$': require.resolve('./__mocks__/@storybook/react-native.jsx'),
   },
   transform: {
     // remove svg asset transformer from expo config, as we configure svg with custom metro transformer


### PR DESCRIPTION
…[no issue]

### Context

When we use addDecorator in a monorepo shared directory context (jest or Storybook config), we want to use always the same one

### Solution

Add a moduleNameMapper for jest

