### PR TITLE
feat(webpack-config): move react-native-web config from storybook and fix for process.browser [no issue]

### DIFF
--- a/@ornikar/storybook-config/addon/webpackFinal.js
+++ b/@ornikar/storybook-config/addon/webpackFinal.js
@@ -6,9 +6,9 @@ const fs = require('fs');
 const path = require('path');
 const linaria = require('@ornikar/webpack-config/linaria');
 const processEnv = require('@ornikar/webpack-config/processEnv');
+const reactNativeWeb = require('@ornikar/webpack-config/reactNativeWeb');
 const resolveFields = require('@ornikar/webpack-config/resolveFields');
 const cssModulesRule = require('../webpack-configs/cssModulesRule');
-const reactNativeWeb = require('../webpack-configs/reactNativeWeb');
 const svgRule = require('../webpack-configs/svgRule');
 const { defaultOptions } = require('./defaultOptions');
 
@@ -55,7 +55,10 @@ module.exports = (
   }
 
   if (enableReactNativeWeb) {
-    reactNativeWeb(env, webpackConfig, { nativeModulesToTranspile });
+    reactNativeWeb(env, webpackConfig, {
+      nativeModulesToTranspile,
+      unshiftToRules: webpackConfig.module.rules,
+    });
   }
 
   webpackConfig.resolve.modules = ['node_modules', 'src'];

--- a/@ornikar/webpack-config/processEnv.js
+++ b/@ornikar/webpack-config/processEnv.js
@@ -7,6 +7,8 @@ module.exports = (env, webpackConfig, { definitions = {}, envVariables = {} } = 
   webpackConfig.plugins.push(
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(env),
+      'process.browser': true,
+      'process.title': '"browser"',
       __DEV__: env !== 'production',
       ...definitions,
       ...Object.fromEntries(Object.entries(envVariables).map(([key, value]) => [`process.env.${key}`, value])),

--- a/@ornikar/webpack-config/reactNativeWeb.js
+++ b/@ornikar/webpack-config/reactNativeWeb.js
@@ -6,8 +6,10 @@ const path = require('path');
 
 const getModule = (name) => path.join('node_modules', name);
 
-module.exports = (env, webpackConfig, { nativeModulesToTranspile }) => {
-  webpackConfig.resolve.extensions = webpackConfig.resolve.extensions.flatMap((ext) => [`.web${ext}`, ext]);
+module.exports = (env, webpackConfig, { nativeModulesToTranspile, unshiftToRules = webpackConfig.module.rules }) => {
+  if (!webpackConfig.resolve.extensions.includes('.web.ts')) {
+    webpackConfig.resolve.extensions = webpackConfig.resolve.extensions.flatMap((ext) => [`.web${ext}`, ext]);
+  }
 
   webpackConfig.resolve.alias = {
     ...webpackConfig.resolve.alias,
@@ -32,7 +34,7 @@ module.exports = (env, webpackConfig, { nativeModulesToTranspile }) => {
     ...nativeModulesToTranspile.map(getModule),
   ];
 
-  webpackConfig.module.rules.push({
+  unshiftToRules.unshift({
     test: /\.(js|jsx|ts|tsx)$/,
     include: (inputPath) => {
       for (const possibleModule of includeModulesThatContainPaths) {

--- a/@ornikar/webpack-config/reactNativeWeb.js
+++ b/@ornikar/webpack-config/reactNativeWeb.js
@@ -6,7 +6,11 @@ const path = require('path');
 
 const getModule = (name) => path.join('node_modules', name);
 
-module.exports = (env, webpackConfig, { nativeModulesToTranspile, unshiftToRules = webpackConfig.module.rules }) => {
+module.exports = (
+  env,
+  webpackConfig,
+  { nativeModulesToTranspile = [], unshiftToRules = webpackConfig.module.rules } = {},
+) => {
   if (!webpackConfig.resolve.extensions.includes('.web.ts')) {
     webpackConfig.resolve.extensions = webpackConfig.resolve.extensions.flatMap((ext) => [`.web${ext}`, ext]);
   }


### PR DESCRIPTION
### Context

Allow react-native-web config to be used in craco config, not only storybook config.
