### PR TITLE
fix(rollup-config): spread runtime helper [no issue]

### DIFF
--- a/@ornikar/rollup-config/__snapshots__/createRollupConfig.test.js.snap
+++ b/@ornikar/rollup-config/__snapshots__/createRollupConfig.test.js.snap
@@ -38,15 +38,10 @@ export { sayHello, testSpread };
 `;
 
 exports[`fixtures test-monorepo 3 1`] = `
-"import _defineProperty from '@babel/runtime/helpers/defineProperty';
+"import _objectSpread from '@babel/runtime/helpers/objectSpread2';
 import _objectWithoutProperties from '@babel/runtime/helpers/objectWithoutProperties';
 
 var _excluded = [\\"name\\"];
-
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
-
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
-
 var sayHello = function () {
   for (var _len = arguments.length, names = new Array(_len), _key = 0; _key < _len; _key++) {
     names[_key] = arguments[_key];

--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -32,7 +32,7 @@ const createBuildsForPackage = (
   const babelRuntimeMinVersion =
     pkg.dependencies && pkg.dependencies['@babel/runtime'] ? pkg.dependencies['@babel/runtime'].slice(1) : undefined;
 
-  if (babelRuntimeMinVersion && /^(^|~)?7\.[0-9]/.test(babelRuntimeMinVersion)) {
+  if (babelRuntimeMinVersion && /^(^|~)?7\.([0-9]\.|1[0-2]|13\.[0-7]$)/.test(babelRuntimeMinVersion)) {
     throw new Error(
       `Please require at least "@babel/runtime"@^7.13.8 in "dependencies" of "${packageName}". Current is "${babelRuntimeMinVersion}"`,
     );

--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -29,6 +29,15 @@ const createBuildsForPackage = (
   const pkg = require(path.resolve(`${rootDir}/${packagesDir}/${packageName}/package.json`));
   if (pkg.private || !pkg.main) return [];
 
+  const babelRuntimeMinVersion =
+    pkg.dependencies && pkg.dependencies['@babel/runtime'] ? pkg.dependencies['@babel/runtime'].slice(1) : undefined;
+
+  if (babelRuntimeMinVersion && /^(^|~)7\.[0-9]$/.test(babelRuntimeMinVersion)) {
+    throw new Error(
+      `Please require at least "@babel/runtime"@^7.13.8 in "dependencies" of "${packageName}". Current is "${babelRuntimeMinVersion}"`,
+    );
+  }
+
   const entries = (pkg.ornikar && pkg.ornikar.entries) || ['index'];
 
   const external = configExternalDependencies({
@@ -148,6 +157,7 @@ const createBuildsForPackage = (
             [
               require.resolve('@babel/plugin-transform-runtime'),
               {
+                version: babelRuntimeMinVersion,
                 corejs: false,
                 helpers: true,
               },

--- a/@ornikar/rollup-config/createRollupConfig.js
+++ b/@ornikar/rollup-config/createRollupConfig.js
@@ -32,7 +32,7 @@ const createBuildsForPackage = (
   const babelRuntimeMinVersion =
     pkg.dependencies && pkg.dependencies['@babel/runtime'] ? pkg.dependencies['@babel/runtime'].slice(1) : undefined;
 
-  if (babelRuntimeMinVersion && /^(^|~)7\.[0-9]$/.test(babelRuntimeMinVersion)) {
+  if (babelRuntimeMinVersion && /^(^|~)?7\.[0-9]/.test(babelRuntimeMinVersion)) {
     throw new Error(
       `Please require at least "@babel/runtime"@^7.13.8 in "dependencies" of "${packageName}". Current is "${babelRuntimeMinVersion}"`,
     );


### PR DESCRIPTION
### Context

`@babel/runtime/helpers/objectSpread2` was not used resulting in a lot of duplicated helpers in code generated by rollup

### Solution

Make sure we use recent `@babel/runtime` version in our lib and pass version in plugin