### PR TITLE
chore(repo-config): replace clean:cache by clean:cache:on-dependencies-changes [no issue]

### DIFF
--- a/@ornikar/repo-config/lib/postinstall/install-husky.js
+++ b/@ornikar/repo-config/lib/postinstall/install-husky.js
@@ -69,7 +69,8 @@ module.exports = function installHusky({ pkg, pm }) {
 
   const shouldRunTest = () => pkg.scripts && pkg.scripts.test;
   const shouldRunChecks = () => pkg.scripts && pkg.scripts.checks;
-  const shouldRunCleanCache = () => pkg.scripts && pkg.scripts['clean:cache'];
+  const shouldRunCleanCacheOnDependenciesChanges = () =>
+    pkg.scripts && pkg.scripts['clean:cache:on-dependencies-changes'];
 
   try {
     fs.mkdirSync(path.resolve('.husky'));
@@ -85,7 +86,7 @@ module.exports = function installHusky({ pkg, pm }) {
     `${pmExec} lint-staged -r${pkg.devDependencies && pkg.devDependencies.typescript ? ` && ${pmExec} tsc` : ''}`,
   );
 
-  const runCleanCache = shouldRunCleanCache();
+  const runCleanCache = shouldRunCleanCacheOnDependenciesChanges();
   if (isYarnPnp && !runCleanCache) {
     ensureHookDeleted('post-checkout');
     ensureHookDeleted('post-merge');
@@ -100,7 +101,7 @@ if [ -n "$(git diff HEAD@{1}..HEAD@{0} -- yarn.lock)" ]; then
       : `yarn install ${
           isYarnBerry ? '--immutable --immutable-cache' : '--prefer-offline --pure-lockfile --ignore-optional'
         } || true`,
-    runCleanCache ? `${pmExec} clean:cache` : '',
+    runCleanCache ? `${pmExec} clean:cache:on-dependencies-changes` : '',
   ]
     .filter(Boolean)
     .join('\n  ')}


### PR DESCRIPTION
if you used clean:cache, add clean:cache:on-dependencies-changes script.
clean:cache should clean all cache, but we dont want to clean everything by default when dependencies changes.
For example, jest cache can still be present

https://ornikar.slack.com/archives/CC9F4CTDH/p1647962343116919