### PR TITLE
fix(webpack-config): fix react-native-web and styled-components/native babelified when not needed [no issue]

### DIFF
--- a/@ornikar/webpack-config/reactNativeWeb.js
+++ b/@ornikar/webpack-config/reactNativeWeb.js
@@ -33,17 +33,18 @@ module.exports = (
     getModule('@use-expo'),
     getModule('@unimodules'),
     getModule('native-base'),
-    getModule('styled-components'),
     // user-defined modules for
     ...nativeModulesToTranspile.map(getModule),
-  ];
+  ].map(path.normalize);
+
+  const excludeModulesThatContainPaths = [getModule('react-native-web')];
 
   unshiftToRules.unshift({
     test: /\.(js|jsx|ts|tsx)$/,
     include: (inputPath) => {
       for (const possibleModule of includeModulesThatContainPaths) {
-        if (inputPath.includes(path.normalize(possibleModule))) {
-          return true;
+        if (inputPath.includes(possibleModule)) {
+          return excludeModulesThatContainPaths.every((excludePath) => !inputPath.includes(excludePath));
         }
       }
       return false;


### PR DESCRIPTION
### Context

styled-components and react-native-web were babelified in webpack config (used by both storybook and applications with craco)
we saw that by testing in sherwood-webapp.

### Solution

Exclude these two libraries
