### PR TITLE
feat(renovate-config): team frontend-shared-components-maintainers [no issue]

### DIFF
--- a/@ornikar/renovate-config/package.json
+++ b/@ornikar/renovate-config/package.json
@@ -202,7 +202,19 @@
           ]
         },
         {
+          "groupName": "Kitt Ornikar",
+          "reviewers": [
+            "team:frontend-shared-components-maintainers"
+          ],
+          "sourceUrlPrefixes": [
+            "https://github.com/ornikar/kitt"
+          ]
+        },
+        {
           "groupName": "Components Ornikar",
+          "reviewers": [
+            "team:frontend-shared-components-maintainers"
+          ],
           "sourceUrlPrefixes": [
             "https://github.com/ornikar/components"
           ],


### PR DESCRIPTION
### Context

Components and kitt PRs will automaticly set reviewer to @ornikar/frontend-shared-components-maintainers  instead of  @ornikar/frontend-architects 

https://ornikar.atlassian.net/wiki/spaces/TECH/pages/3204677657/Shared+React+Components+2022-04-26