### PR TITLE
fix(ornikar-test-coverage): jest collect coverage output path [no issue]

### DIFF
--- a/@ornikar/jest-config/bin/test-coverage.sh
+++ b/@ornikar/jest-config/bin/test-coverage.sh
@@ -3,7 +3,7 @@
 # exit when any command fails
 set -e
 
-rm -Rf test-coverage
+rm -Rf coverage
 
 if [ -z "$1" ]; then
   yarn test --collectCoverage --watchAll=false

--- a/@ornikar/jest-config/bin/test-coverage.sh
+++ b/@ornikar/jest-config/bin/test-coverage.sh
@@ -11,4 +11,4 @@ else
   yarn test --collectCoverage --watchAll=false --findRelatedTests $1 --collectCoverageOnlyFrom="$1" --passWithNoTests
 fi
 
-open test-coverage/lcov-report/index.html
+open coverage/lcov-report/index.html


### PR DESCRIPTION
BREAKING CHANGE: jest collect coverage output directory needs to be `coverage`
