### PR TITLE
fix(intl-config): fix peer dep requires min babel core ^7.13.0 [no issue]

### DIFF
--- a/@ornikar/intl-config/package.json
+++ b/@ornikar/intl-config/package.json
@@ -22,6 +22,6 @@
     "@babel/core": "7.17.7"
   },
   "peerDependencies": {
-    "@babel/core": "^7.4.3"
+    "@babel/core": "^7.13.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3660,7 +3660,7 @@ __metadata:
     babel-plugin-formatjs: ^10.3.18
     glob: ^7.1.6
   peerDependencies:
-    "@babel/core": ^7.4.3
+    "@babel/core": ^7.13.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Context

this option is only available since 7.13.0 : https://babeljs.io/docs/en/options#browserslistconfigfile

Note: this is not a breaking change as past versions crashed without this babel version