### PR TITLE
feat(jest-config-react-native): support for react-native-svg-web ELN-3031

### DIFF
--- a/@ornikar/jest-config-react-native/web/jest-preset.js
+++ b/@ornikar/jest-config-react-native/web/jest-preset.js
@@ -18,6 +18,7 @@ module.exports = {
   moduleNameMapper: {
     ...baseOrnikarPreset.moduleNameMapper,
     ...expoPreset.moduleNameMapper,
+    '^react-native-svg$': 'react-native-svg-web',
   },
   transformIgnorePatterns: ornikarReactNativePreset.transformIgnorePatterns,
   transform: {


### PR DESCRIPTION
### Context
Dans le cadre de l'utilisation de `react-native-svg` dans le web, et surtout dans les stories jest, on souhaite mapper les improts vers `react-native-svg` vers `react-native-svg-web` pour que le rendu snapshots des stories fonctionnent correctement 👍 