### PR TITLE
feat(repo-config): skip husky install on ci [no issue]

### DIFF
--- a/@ornikar/repo-config/lib/postinstall/install-husky.js
+++ b/@ornikar/repo-config/lib/postinstall/install-husky.js
@@ -162,5 +162,8 @@ fi
     ensureHookDeleted('pre-push');
   }
 
-  husky.install('.husky');
+  // skip install husky on CI as we don't need it
+  if (!process.env.CI) {
+    husky.install('.husky');
+  }
 };


### PR DESCRIPTION
### Context

- With yarn berry, we will run the install script on every jobs
- husky is not necessary to use on CI. Even for jobs that commit stuff, they should not rely on lint-staged to fix formatting.

### Solution

skip husky install on CI using `process.env.CI`

### Risk

This might cause issues on monorepo libraries when releasing