### PR TITLE
fix(repo-config): fix prettier env files [no issue]

### DIFF
--- a/@ornikar/repo-config/createLintStagedConfig.js
+++ b/@ornikar/repo-config/createLintStagedConfig.js
@@ -40,9 +40,7 @@ module.exports = function createLintStagedConfig(options = {}) {
         `git add yarn.lock${yarnConfigFile ? ' .yarn' : ''}`,
       ].filter(Boolean);
     },
-    '!(package).json': ['prettier --write'],
-    '*.{yml,yaml,md,html,env}': ['prettier --write'],
-    '.env*': ['prettier --write'],
+    '{.env*,!(package).json,*.{yml,yaml,md,html,env}}': ['prettier --write'],
     [`*.{${srcExtensions.join(',')}}`]: ['prettier --write', 'eslint --fix --quiet'],
     [`{.storybook,${srcDirectories}}/**/*.css`]: ['prettier --parser css --write', 'stylelint --quiet --fix'],
   };

--- a/@ornikar/repo-config/createLintStagedConfig.js
+++ b/@ornikar/repo-config/createLintStagedConfig.js
@@ -41,8 +41,8 @@ module.exports = function createLintStagedConfig(options = {}) {
       ].filter(Boolean);
     },
     '!(package).json': ['prettier --write'],
-    '*.{yml,yaml,md,html}': ['prettier --write'],
-    '.env*': ['prettier --parser dot-properties --key-separator "=" --no-single-quote --write'],
+    '*.{yml,yaml,md,html,env}': ['prettier --write'],
+    '.env*': ['prettier --write'],
     [`*.{${srcExtensions.join(',')}}`]: ['prettier --write', 'eslint --fix --quiet'],
     [`{.storybook,${srcDirectories}}/**/*.css`]: ['prettier --parser css --write', 'stylelint --quiet --fix'],
   };


### PR DESCRIPTION
### Context

Followup of https://github.com/ornikar/shared-configs/pull/764

### Solution

- no longer specify arguments for `.env*` to prettier in lint-staged
- add prettier for `*.env`