### PR TITLE
feat(repo-config): only run tsc on pre-commit when ts file changed [no issue]

### DIFF
--- a/@ornikar/repo-config/createLintStagedConfig.js
+++ b/@ornikar/repo-config/createLintStagedConfig.js
@@ -43,6 +43,7 @@ module.exports = function createLintStagedConfig(options = {}) {
     '{.env*,!(package).json,*.{yml,yaml,md,html,env}}': ['prettier --write'],
     [`*.{${srcExtensions.join(',')}}`]: ['prettier --write', 'eslint --fix --quiet'],
     [`{.storybook,${srcDirectories}}/**/*.css`]: ['prettier --parser css --write', 'stylelint --quiet --fix'],
+    [`${srcDirectories}/**/*.{ts,tsx}`]: () => ['tsc'],
   };
 };
 

--- a/@ornikar/repo-config/lib/postinstall/install-husky.js
+++ b/@ornikar/repo-config/lib/postinstall/install-husky.js
@@ -82,10 +82,7 @@ module.exports = function installHusky({ pkg, pm }) {
   const pmExec = pm.name === 'npm' ? 'npx --no-install' : pm.name;
 
   writeHook('commit-msg', `${pmExec} commitlint --edit $1`);
-  writeHook(
-    'pre-commit',
-    `${pmExec} ornikar-lint-staged${pkg.devDependencies && pkg.devDependencies.typescript ? ` && ${pmExec} tsc` : ''}`,
-  );
+  writeHook('pre-commit', `${pmExec} ornikar-lint-staged`);
 
   const runCleanCache = shouldRunCleanCacheOnDependenciesChanges();
   if (isYarnPnp && !runCleanCache) {


### PR DESCRIPTION
## Context

Currently, `tsc` is ran on every pre-commit, after lint-staged.
tsc can be slow on big projects.
CI checks tsc too.

## Solution

Using lint-staged to run tsc will:
- run tsc in parallel with the other tasks (eslint/yarn etc)
- only run tsc when ts/tsx file changed

