### PR TITLE
feat: use generic release alert workflow instead of local one

### DIFF
--- a/.github/workflows/release-alert.yml
+++ b/.github/workflows/release-alert.yml
@@ -1,46 +1,9 @@
-# This is a basic workflow to help you get started with Actions
 name: ReleaseAlert
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   release:
     types: [published]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      - name: Dump Github context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
-      - name: Slack Notification on SUCCESS
-        if: success()
-        uses: tokorom/action-slack-incoming-webhook@main
-        env:
-          INCOMING_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          text: A release is published.
-          blocks: |
-            [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "<${{ github.event.release.html_url }}|${{ github.event.release.tag_name}}>"
-                }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": ${{ toJSON(github.event.release.body) }}
-                }
-              }
-            ]
+  alert:
+    uses: ornikar/.github/workflows/release-alert.yml@main


### PR DESCRIPTION
### Context

En lien avec https://github.com/ornikar/.github/pull/7/files
On ne peut pas tester les `reusable workflows` avec `act`. Obligé de "tester en prod"

### Solution

On utilise le workflow générique.

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- Uncomment this if you have a mixpanel dashboard related to this PR that allows us to track it in production
### Mixpanel dashboard

- Staging: Link
- Production: Link
-->
