### PR TITLE
fix(jest-config-react): fix testing library cleanup ECF-58

### DIFF
--- a/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
+++ b/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
@@ -2,9 +2,6 @@
 
 'use strict';
 
-const { render, waitFor } = require('@testing-library/react-native');
-const React = require('react');
-
 const decorateStory = (storyFn, decorators) =>
   // eslint-disable-next-line unicorn/no-array-reduce
   decorators.reduce(
@@ -48,6 +45,9 @@ exports.action = (actionName) => jest.fn();
 
 // Mocked version of: `import { storiesOf } from '@storybook/react-native'`
 exports.storiesOf = (groupName) => {
+  // eslint-disable-next-line global-require -- importing here allows cleanup to be called and prevent useless require in all tests as decorators/parameters are added in test-setup, before all tests
+  const { render, waitFor } = require('@testing-library/react-native');
+
   const localDecorators = [];
   const localParameters = {};
 

--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -2,8 +2,6 @@
 
 'use strict';
 
-const { render, waitFor } = require('@testing-library/react');
-
 const decorateStory = (storyFn, decorators) =>
   decorators.reduce(
     (decorated, decorator) =>
@@ -44,6 +42,10 @@ exports.action = (actionName) => jest.fn();
 
 // Mocked version of: `import { storiesOf } from '@storybook/react'`
 exports.storiesOf = (groupName) => {
+  // eslint-disable-next-line global-require -- importing here allows cleanup to be called and prevent useless require in all tests as decorators/parameters are added in test-setup, before all tests
+  const { render, waitFor } = require('@testing-library/react');
+  // testing-library registers cleanup via afterEach, which is not available in test-setup, only on test-setup-after-env.
+
   const localDecorators = [];
   const localParameters = {};
 


### PR DESCRIPTION
### Context

The cleanup function in testing-library/react should be called automaticly. However it is never called, resulting in performance issues (memory leaks ?) and sometimes invalid tests.

### Solution

testing-library registers cleanup via afterEach, which is not available in test-setup, only on test-setup-after-env
We import testing-library in test-setup via storybook mocks, as we add decorators/parameters

The solution is to move the import in the `storiesOf` which should be called only once on each story test file. This way, in the test-setup phase, testing-library is no longer imported, and afterEach will be available when `storiesOf` is called
This also has another benefits: for tests not using testing-library, it will never be imported.

Perf test using hyperfine:

Impact on time on react (components / warm cache): (no change)
- before: 36.123 s ±  0.649 
- after: 35.024 s ±  1.494 s    


Also do that on react-native. We don't seem to have a problem, but there is a cleanup function too.
Impact on time on react-native (instructors-app / warm cache): (no change)
- before: 205s
- after: 202s
