### PR TITLE
feat: log errors during ornikar-lint-staged command [no issue]

### DIFF
--- a/@ornikar/repo-config/bin/ornikar-lint-staged.mjs
+++ b/@ornikar/repo-config/bin/ornikar-lint-staged.mjs
@@ -12,6 +12,6 @@ lintStaged({
     process.exitCode = passed ? 0 : 1;
   })
   .catch((error) => {
-    console.log(error);
+    console.error(error);
     process.exitCode = 1;
   });

--- a/@ornikar/repo-config/bin/ornikar-lint-staged.mjs
+++ b/@ornikar/repo-config/bin/ornikar-lint-staged.mjs
@@ -11,6 +11,7 @@ lintStaged({
   .then((passed) => {
     process.exitCode = passed ? 0 : 1;
   })
-  .catch(() => {
+  .catch((error) => {
+    console.log(error);
     process.exitCode = 1;
   });


### PR DESCRIPTION
### Context

https://ornikar.slack.com/archives/CC9F4CTDH/p1668002640656459
Husky was failing silently during the precommit phase. ornikar-lint-staged was catching an error (here I had a dependency mismatch between repo-config & lerna-config) but did not log it in the console.

### Solution

Add a console.log(error).

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- Uncomment this if you have a mixpanel dashboard related to this PR that allows us to track it in production
### Mixpanel dashboard

- Staging: Link
- Production: Link
-->
