### PR TITLE
fix: remove test shim [no issue]

### DIFF
--- a/@ornikar/jest-config/jest-preset.js
+++ b/@ornikar/jest-config/jest-preset.js
@@ -27,7 +27,6 @@ module.exports = {
   modulePaths: useLerna ? [] : ['<rootDir>/src'],
   setupFilesAfterEnv: [require.resolve('./test-setup-after-env.js')],
   setupFiles: [
-    require.resolve('./test-shim.js'),
     require.resolve('./global-mocks.js'),
     // project setup should always be placed last.
     '<rootDir>/test-setup.js',

--- a/@ornikar/jest-config/test-shim.js
+++ b/@ornikar/jest-config/test-shim.js
@@ -1,9 +1,0 @@
-'use strict';
-
-global.requestAnimationFrame = (callback) => {
-  setTimeout(callback, 0);
-};
-
-global.cancelAnimationFrame = (callback) => {
-  setTimeout(callback, 0);
-};


### PR DESCRIPTION
mocking requestAnimationFrame is no longer necessary
and has issues linked to setTimeout / jest timeouts


Tested on kitt and learner-apps.