### PR TITLE
fix: update config for Jest 27 ONK-4620

### DIFF
--- a/@ornikar/jest-config-react-native/package.json
+++ b/@ornikar/jest-config-react-native/package.json
@@ -18,6 +18,7 @@
   "peerDependencies": {
     "@testing-library/react-hooks": "^7.0.0",
     "@testing-library/react-native": "^7.2.0 || ^8.0.0 || ^9.0.0",
+    "jest": "^27.0.0",
     "jest-expo": "^41.0.0 || ^42.0.0 || ^43.0.0 || ^44.0.0 || ^45.0.0 ||^46.0.0 || ^47.0.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"

--- a/@ornikar/jest-config-react-native/transformers/babel-transformer-node-modules.js
+++ b/@ornikar/jest-config-react-native/transformers/babel-transformer-node-modules.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-const babelJest = require('babel-jest');
+const babelJest = require('babel-jest').default;
 
 module.exports = babelJest.createTransformer({
   // should be identical to the config in @ornikar/webpack-configs/reactNativeWeb.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -3093,6 +3093,7 @@ __metadata:
   peerDependencies:
     "@testing-library/react-hooks": ^7.0.0
     "@testing-library/react-native": ^7.2.0 || ^8.0.0 || ^9.0.0
+    jest: ^27.0.0
     jest-expo: ^41.0.0 || ^42.0.0 || ^43.0.0 || ^44.0.0 || ^45.0.0 ||^46.0.0 || ^47.0.0
     react: ^17.0.0
     react-dom: ^17.0.0


### PR DESCRIPTION
### Context

Following the migration to Jest 27 (#812), some config needs to be updated.

### Solution

- Add missing the peer dep `jest` in the `jest-config-react-native/package.json` file
- Fix the import of `babel-jest` (relative issue => https://app.circleci.com/pipelines/github/ornikar/insurance-selfcare-webapp/5311/workflows/8766ebcc-8e31-4eb6-82a0-2f3826dd3a46/jobs/32440)