### PR TITLE
feat: ignore act warnings from rtl [no issue]

### DIFF
--- a/@ornikar/jest-config/test-setup-after-env.js
+++ b/@ornikar/jest-config/test-setup-after-env.js
@@ -16,6 +16,8 @@ const deprecatedReactLifeCycleMethods = [
 
 failOnConsole({
   silenceMessage: (message) => {
+    // Do not ignore the act / await warning anymore once we are on React 18
+    if (message.includes('You called act(async () => ...) without await')) return true;
     return deprecatedReactLifeCycleMethods.some((lifecycleMethod) =>
       message.includes(`${lifecycleMethod} has been renamed, and is not recommended for use.`),
     );


### PR DESCRIPTION
### Context

Des warnings non justifiés apparaissent avec la MAJ de jest 27

### Solution

On les ignore jusqu'à la MAJ de React 18, qui les enlèvera tout seul

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- Uncomment this if you have a mixpanel dashboard related to this PR that allows us to track it in production
### Mixpanel dashboard

- Staging: Link
- Production: Link
-->
