### PR TITLE
feat(lerna-config): add explicit conventional-changelog-conventionalcommits dependency [no issue]

### DIFF
--- a/@ornikar/lerna-config/package.json
+++ b/@ornikar/lerna-config/package.json
@@ -34,7 +34,8 @@
     "@lerna/project": "5.5.4",
     "@lerna/publish": "5.5.4",
     "@lerna/version": "5.5.4",
-    "@pob/pretty-eslint-config": "^3.0.0"
+    "@pob/pretty-eslint-config": "^3.0.0",
+    "conventional-changelog-conventionalcommits": "^5.0.0"
   },
   "scripts": {
     "lint:eslint": "yarn ../.. eslint --report-unused-disable-directives --quiet @ornikar/lerna-config"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3262,6 +3262,7 @@ __metadata:
     "@lerna/publish": 5.5.4
     "@lerna/version": 5.5.4
     "@pob/pretty-eslint-config": ^3.0.0
+    conventional-changelog-conventionalcommits: ^5.0.0
   peerDependencies:
     lerna: 0.0.0
   peerDependenciesMeta:


### PR DESCRIPTION
### Context

Configure lerna to understand bang `!` breaking changes

Example: `feat!: upgrade to node 16`

### Solution

Add explicit `conventional-changelog-conventionalcommits` dependency
Today this dependency is already used by our commitlint config, but this is not the same use case
