### PR TITLE
fix: update transformers for jest 29 [no issue]

### DIFF
--- a/@ornikar/jest-config-react/transformers/svg-transformer-inline.js
+++ b/@ornikar/jest-config-react/transformers/svg-transformer-inline.js
@@ -5,15 +5,13 @@ const path = require('path');
 exports.process = function process(src, filePath) {
   const assetFilename = JSON.stringify(path.basename(filePath));
   return {
-    code: `
-    const { jsx } = require('react/jsx-runtime');
-    function JestSvgComponent(props) {
-    return jsx(
-      'svg',
-      Object.assign({}, props, {'data-file-name': ${assetFilename}})
-    );
-    }
-    module.exports = JestSvgComponent;
-              `,
+    code: `const { jsx } = require('react/jsx-runtime');
+function JestSvgComponent(props) {
+return jsx(
+  'svg',
+  Object.assign({}, props, {'data-file-name': ${assetFilename}})
+);
+}
+module.exports = JestSvgComponent;`,
   };
 };

--- a/@ornikar/jest-config-react/transformers/svg-transformer.js
+++ b/@ornikar/jest-config-react/transformers/svg-transformer.js
@@ -5,22 +5,24 @@ const { process } = require('./svg-transformer-inline');
 
 exports.process = (src, filePath) => {
   const assetFilename = JSON.stringify(path.basename(filePath));
-  const content = process(src, filePath);
-  return content.replace(
-    /module.exports = (.*);/,
-    `module.exports = new Proxy({}, {
-    get: function getter(target, key) {
-      if (key === '__esModule') {
-        return true;
-      }
-      if (key === 'default') {
-        return ${assetFilename};
-      }
-      if (key === 'ReactComponent') {
-        return $1;
-      }
-      throw new Error('Invalid key for svg-transformer jest mock: ' + key);
+  const { code } = process(src, filePath);
+  return {
+    code: code.replace(
+      /module.exports = (.*);/,
+      `module.exports = new Proxy({}, {
+  get: function getter(target, key) {
+    if (key === '__esModule') {
+      return true;
     }
-  });`,
-  );
+    if (key === 'default') {
+      return ${assetFilename};
+    }
+    if (key === 'ReactComponent') {
+      return $1;
+    }
+    throw new Error('Invalid key for svg-transformer jest mock: ' + key);
+  }
+});`,
+    ),
+  };
 };


### PR DESCRIPTION
### Context

jest 29 requires to use `code` as return to the process() function