### PR TITLE
fix: use sucrase for most cases in custom transformers [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/customTransforms.js
+++ b/@ornikar/jest-config-react-native/customTransforms.js
@@ -6,15 +6,30 @@
 
 exports.customTransforms = {
   // compilation of problematic node_modules has a simpler babel config
-  'node_modules/(react-native-(calendars|reanimated)|native-base|@react-native-community/netinfo)/.*\\.(js|jsx|ts|tsx)$':
+  'node_modules/(react-native-(calendars|reanimated)|@react-native-community/netinfo)/.*\\.(js|jsx|ts|tsx)$':
     require.resolve('./transformers/babel-transformer-node-modules.js'),
 
   // dont transform node_modules when already compiled
-  'node_modules/.*/(commonjs|dist/(cjs|vendor))/.*\\.js$': require.resolve('./transformers/identity-transformer.js'),
+  'node_modules/.*/(commonjs|dist/(cjs|vendor)|build/)/.*\\.js$': require.resolve(
+    './transformers/identity-transformer.js',
+  ),
 
-  // compilation of most node_modules with sucrase for faster setup
-  'node_modules/(@?react-native.*|@?expo.*|@?react-navigation.*)/.*\\.(js|jsx|ts|tsx)$': '@sucrase/jest-plugin',
+  // compilation of react-native with sucrase fails since expo 48 update
+  'node_modules/react-native/.*\\.(js|jsx|ts|tsx)$': require.resolve(
+    './transformers/babel-transformer-node-modules.js',
+  ),
 
-  // compilation of rest node_modules has a simpler babel config (might be additional transformIgnorePatterns)
-  'node_modules.*\\.(js|jsx|ts|tsx)$': require.resolve('./transformers/babel-transformer-node-modules.js'),
+  // https://github.com/expo/expo/blob/d5d454eb585bdd8fb1a07e2910ba99dca8fd8786/packages/@expo/metro-config/src/transformer/createMultiRuleTransformer.ts#L207
+  'node_modules/(expo-processing|@expo/vector-icons)/.*\\.(js|jsx|ts|tsx)$': [
+    '@sucrase/jest-plugin',
+    { transforms: ['jsx', 'imports'] },
+  ],
+  'node_modules/(expo-assets-utils)/.*\\.(js|jsx|ts|tsx)$': [
+    '@sucrase/jest-plugin',
+    { transforms: ['flow', 'imports'] },
+  ],
+  'node_modules/(@?(use-)?expo.*)/.*\\.(js|jsx|ts|tsx)$': ['@sucrase/jest-plugin', { transforms: ['imports'] }],
+
+  // compilation of rest node_modules with sucrase
+  'node_modules.*\\.(js|jsx|ts|tsx)$': '@sucrase/jest-plugin',
 };


### PR DESCRIPTION
### Context

Based on expo config for jest 29 with react 18, but also works with react 17
see https://github.com/ornikar/shared-configs/pull/866

Without this, node_modules passes through babel, which does not support all things like private methods

![image](https://user-images.githubusercontent.com/302891/227238717-ab737514-3051-4a05-90f0-fd952cbe7d9d.png)
