### PR TITLE
fix(intl-config): add newline eof to match editorconfig [no issue]

### DIFF
--- a/@ornikar/intl-config/extract-translations.js
+++ b/@ornikar/intl-config/extract-translations.js
@@ -79,7 +79,7 @@ module.exports = ({ paths, babelPluginFormatjsOptions = {}, defaultDestinationDi
     const destinationFolder = path.dirname(destinationFile);
 
     fs.mkdirSync(destinationFolder, { recursive: true });
-    fs.writeFileSync(destinationFile, JSON.stringify(sortedDefaultMessages, null, 2));
+    fs.writeFileSync(destinationFile, `${JSON.stringify(sortedDefaultMessages, null, 2)}\n`);
   });
   return { phraseSources, phraseTargets };
 };


### PR DESCRIPTION
### Context

Currently if we edit an fr-FR.json in our IDE and save it (or have autosave enabled), this will add a newline at the end and ci will fail as it does not match content generated by script.

### Solution

Add a newline to match what we ask of the IDE