### PR TITLE
feat: deprecate stylelint [no issue]

### DIFF
--- a/@ornikar/repo-config/createLintStagedConfig.js
+++ b/@ornikar/repo-config/createLintStagedConfig.js
@@ -8,6 +8,7 @@ const pkg = require(path.resolve('package.json'));
 const workspaces = pkg.workspaces || false;
 const isLernaRepo = Boolean(pkg.devDependencies && pkg.devDependencies.lerna);
 const hasTypescript = Boolean(pkg.devDependencies && pkg.devDependencies.typescript);
+const hasDeprecatedStylelint = Boolean(pkg.devDependencies && pkg.devDependencies.stylelint);
 const shouldGenerateTsconfigInLernaRepo = isLernaRepo && hasTypescript;
 const shouldRunCheckPkgJSScript = fs.existsSync('./scripts/check-packagejson.js');
 const shouldRunCheckPkgMJSScript = fs.existsSync('./scripts/check-packagejson.mjs');
@@ -45,7 +46,10 @@ module.exports = function createLintStagedConfig(options = {}) {
       }
       return [`prettier --write -- ${filenames.join(' ')}`, `eslint --fix --quiet -- ${filenames.join(' ')}`];
     },
-    [`{.storybook,${srcDirectories}}/**/*.css`]: ['prettier --parser css --write', 'stylelint --quiet --fix'],
+    [`{.storybook,${srcDirectories}}/**/*.css`]: [
+      'prettier --parser css --write',
+      hasDeprecatedStylelint ? 'stylelint --quiet --fix' : undefined,
+    ].filter(Boolean),
     [`${srcDirectories}/**/*.{ts,tsx}`]: () => ['tsc'],
   };
 };

--- a/@ornikar/stylelint-config/README.md
+++ b/@ornikar/stylelint-config/README.md
@@ -1,5 +1,7 @@
 # @ornikar/stylelint-config
 
+DEPRECATED: with kitt-universal, use css in js which is linted by eslint and typescript.
+
 Ornikar stylelint config
 
 ## styled-components for the web


### PR DESCRIPTION
### Context

We currently use stylelint with an old version. We don't want to use stylelint now with css in js and native-base, which is linted via typescript and eslint.
This still allows stylint usage for legacy projects, but allow newer ones to remove it and remove the security alerts linked to it.