### PR TITLE
fix(storybook-config): usage with cra addon ECF-228

### DIFF
--- a/@ornikar/storybook-config/addon/webpackFinal.js
+++ b/@ornikar/storybook-config/addon/webpackFinal.js
@@ -19,6 +19,7 @@ module.exports = (
     enableReactNativeWeb = false,
     enableLinaria = false,
     enableLegacyCssModules = false,
+    isCRAPresetEnabled = false,
     modulesToAlias = {},
     nativeModulesToTranspile = [],
     envVariables,
@@ -48,9 +49,11 @@ module.exports = (
   const env = process.env.NODE_ENV !== 'production' ? 'dev' : 'production';
 
   if (enableLegacyCssModules) {
-    cssModulesRule(env, webpackConfig, srcDirectories);
+    cssModulesRule(env, webpackConfig, srcDirectories, isCRAPresetEnabled);
   }
-  svgRule(env, webpackConfig);
+  if (!isCRAPresetEnabled) {
+    svgRule(env, webpackConfig);
+  }
   fixStorybookBabelRules(env, webpackConfig);
 
   if (enableLinaria) {

--- a/@ornikar/storybook-config/index.js
+++ b/@ornikar/storybook-config/index.js
@@ -26,6 +26,8 @@ exports.createMainConfig = function createMainConfig({
     throw new Error('When disablePostcssAddon=true, you should not provide postcssImplementation');
   }
 
+  const isCRAPresetEnabled = addons.includes('@storybook/preset-create-react-app');
+
   return {
     core: {
       builder: 'webpack5',
@@ -37,7 +39,7 @@ exports.createMainConfig = function createMainConfig({
     addons: [
       disablePostcssAddon ||
       // When cra preset is already installed, we should not have postcss addon
-      addons.includes('@storybook/preset-create-react-app')
+      isCRAPresetEnabled
         ? null
         : {
             name: '@storybook/addon-postcss',
@@ -58,7 +60,7 @@ exports.createMainConfig = function createMainConfig({
         },
       },
       ...addons,
-      { name: require.resolve('./preset'), options: ornikarAddonOptions },
+      { name: require.resolve('./preset'), options: { ...ornikarAddonOptions, isCRAPresetEnabled } },
     ].filter(Boolean),
   };
 };

--- a/@ornikar/storybook-config/webpack-configs/cssModulesRule.js
+++ b/@ornikar/storybook-config/webpack-configs/cssModulesRule.js
@@ -8,11 +8,13 @@ module.exports = (env, webpackConfig, srcDirectories, isCRAPresetEnabled) => {
     const cssModuleRule = rules.find(
       (rule) => !rule.exclude && rule.test && rule.test.toString() === /\.module\.css$/.toString(),
     );
-    cssModuleRule.use = [
-      ...cssModuleRule.use.slice(0, -1),
-      '@chrp/typed-css-modules-loader',
-      ...cssModuleRule.use.slice(-1),
-    ];
+    if (process.env.NODE_ENV !== 'production') {
+      cssModuleRule.use = [
+        ...cssModuleRule.use.slice(0, -1),
+        '@chrp/typed-css-modules-loader',
+        ...cssModuleRule.use.slice(-1),
+      ];
+    }
 
     return;
   }

--- a/@ornikar/storybook-config/webpack-configs/cssModulesRule.js
+++ b/@ornikar/storybook-config/webpack-configs/cssModulesRule.js
@@ -2,7 +2,21 @@
 
 const path = require('path');
 
-module.exports = (env, webpackConfig, srcDirectories) => {
+module.exports = (env, webpackConfig, srcDirectories, isCRAPresetEnabled) => {
+  if (isCRAPresetEnabled) {
+    const rules = webpackConfig.module.rules[2].oneOf;
+    const cssModuleRule = rules.find(
+      (rule) => !rule.exclude && rule.test && rule.test.toString() === /\.module\.css$/.toString(),
+    );
+    cssModuleRule.use = [
+      ...cssModuleRule.use.slice(0, -1),
+      '@chrp/typed-css-modules-loader',
+      ...cssModuleRule.use.slice(-1),
+    ];
+
+    return;
+  }
+
   const cssRule = webpackConfig.module.rules.find((rule) => rule.test && rule.test.toString() === /\.css$/.toString());
   cssRule.exclude = /\.module\.css$/;
   cssRule.sideEffects = true;


### PR DESCRIPTION
### Context

cra addon is used only in sherwood-webapp.
While testing, it was broken: postcss rule should not be applied in the same way
Fix config for CRA addon.