### PR TITLE
fix(webpack-config): add define process.version for jsonwebtoken [no issue]

### DIFF
--- a/@ornikar/webpack-config/processEnv.js
+++ b/@ornikar/webpack-config/processEnv.js
@@ -12,6 +12,7 @@ module.exports = (env, webpackConfig, { definitions = {}, envVariables = {}, str
       // NOTE: process.env.NODE_ENV is defined by storybook and CRA5.
       'process.browser': true,
       'process.title': '"browser"',
+      'process.version': 'null',
       __DEV__: env !== 'production',
       ...definitions,
       ...Object.fromEntries(


### PR DESCRIPTION
### Context

`process.version` is used in https://github.com/auth0/node-jsonwebtoken/blob/master/lib/asymmetricKeyDetailsSupported.js