### PR TITLE
feat!: use linaria webpack5 loader [no issue]

### DIFF
--- a/@ornikar/webpack-config/linaria.js
+++ b/@ornikar/webpack-config/linaria.js
@@ -6,7 +6,7 @@ module.exports = (env, webpackConfig) => {
     exclude: /node_modules/,
     use: [
       {
-        loader: '@linaria/webpack-loader',
+        loader: '@linaria/webpack5-loader',
         options: {
           sourceMap: env !== 'production',
           extension: '.css',


### PR DESCRIPTION
BREAKING CHANGE: instead of @linaria/webpack-loader dependency, install @linaria/webpack5-loader

Fix a security issue present in @linaria/webpack4-loader

@linaria/webpack-loader install both @linaria/webpack4-loader and @linaria/webpack5-loader