### PR TITLE
feat(jest-config-react-native): add testEnvironment config for native [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/jest-preset.js
+++ b/@ornikar/jest-config-react-native/jest-preset.js
@@ -18,6 +18,7 @@ module.exports = {
     '@storybook/react$': require.resolve('./__mocks__/@storybook/react-native.jsx'),
     '^@storybook/react$': require.resolve('./__mocks__/@storybook/react-native.jsx'),
   },
+  testEnvironment: require.resolve('./ornikar-react-native-env.js'),
   // override expo transformIgnorePatterns with custom config
   transformIgnorePatterns: [
     'node_modules/(?!(react-native.*|@react-native.*|expo.*|@expo(nent)?/.*|react-navigation.*|@react-navigation/.*|native-base)/)',

--- a/@ornikar/jest-config-react-native/ornikar-react-native-env.js
+++ b/@ornikar/jest-config-react-native/ornikar-react-native-env.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// eslint-disable-next-line import/no-unresolved
+const ReactNativeEnv = require('react-native/jest/react-native-env');
+
+module.exports = class OrnikarReactNativeEnv extends ReactNativeEnv {
+  // eslint-disable-next-line class-methods-use-this
+  exportConditions() {
+    return ['react-native', 'jest'];
+  }
+};

--- a/@ornikar/jest-config-react-native/web/jest-preset.js
+++ b/@ornikar/jest-config-react-native/web/jest-preset.js
@@ -8,6 +8,7 @@ const ornikarReactNativePreset = require('../jest-preset');
 module.exports = {
   ...baseOrnikarPreset,
   ...expoPreset,
+  testEnvironment: baseOrnikarPreset.testEnvironment, // override testEnvironment in expo preset
   snapshotResolver: require.resolve('../snapshot-resolvers/resolver.web.js'),
   setupFiles: [...expoPreset.setupFiles, ...baseOrnikarPreset.setupFiles, require.resolve('../test-setup')],
   testMatch: [


### PR DESCRIPTION
### Context

Currently importing ornikar libraries with `exports` configuration fails because of missing react-native export.

react-native configuration of jest only allows `react-native` condition, but it is the same one that the one metro is experimenting with. We need to differenciate both of them, to precompile our libraries for the target properly.

This configuration allows this kind of exports:

<img width="446" alt="image" src="https://github.com/ornikar/shared-configs/assets/302891/dba583e2-dd49-4cad-ae10-74273332499f">
