### PR TITLE
fix(lerna-config): tsconfig generation without baseurl [no issue]

### DIFF
--- a/@ornikar/lerna-config/bin/generate-tsconfig-files.mjs
+++ b/@ornikar/lerna-config/bin/generate-tsconfig-files.mjs
@@ -59,9 +59,10 @@ import { getGraphPackages } from '../index.mjs';
 
       const filteredCurrentCompilerOptions = tsconfigCurrentContent.compilerOptions || {};
       const isLegacyRootDirDot = !existsSync(path.join(packagePath, 'src'));
+      const isApp = !tsconfigBuildPath;
       const compilerOptions = {
         rootDir: isLegacyRootDirDot ? '.' : 'src',
-        baseUrl: isLegacyRootDirDot ? '.' : './src',
+        baseUrl: isApp ? undefined : isLegacyRootDirDot ? '.' : './src',
         composite: true,
         incremental: true,
         isolatedModules: true,
@@ -77,6 +78,9 @@ import { getGraphPackages } from '../index.mjs';
       Object.keys(compilerOptions).forEach((key) => {
         delete filteredCurrentCompilerOptions[key];
       });
+      if (!isApp) {
+        delete compilerOptions.baseUrl;
+      }
 
       const tsconfigContent = {
         extends: '../../tsconfig.base.json',
@@ -123,10 +127,10 @@ import { getGraphPackages } from '../index.mjs';
       // react-scripts doesn't like paths
       if (!pkg.private) {
         tsconfigContent.compilerOptions.paths = {
-          [pkg.name]: ['./index.ts'],
+          [pkg.name]: ['./src/index.ts'],
         };
         tsconfigBuildContent.compilerOptions.paths = {
-          [pkg.name]: ['./index.ts'],
+          [pkg.name]: ['./src/index.ts'],
         };
       }
 
@@ -150,7 +154,7 @@ import { getGraphPackages } from '../index.mjs';
       if (tsDependencies.length > 0) {
         tsDependencies.forEach((pkgDep) => {
           const pkgRelativePath = path.relative(pkgDep.rootPath, pkgDep.location);
-          const depPath = `../../../${pkgRelativePath}/src`;
+          const depPath = `../../${pkgRelativePath}/src`;
           if (!tsconfigContent.compilerOptions.paths) {
             tsconfigContent.compilerOptions.paths = {};
           }


### PR DESCRIPTION
### Context

Using baseurl causes issues for distribution files, as seen multiple times like https://github.com/ornikar/shared-apps/pull/731.

### Solution

stop using baseUrl for libraries and use relative imports

