### PR TITLE
feat: silence warnings linked to react-native-web 19 INS-2508

### DIFF
--- a/@ornikar/jest-config-react/test-setup-after-env.js
+++ b/@ornikar/jest-config-react/test-setup-after-env.js
@@ -33,6 +33,14 @@ failOnConsole({
       return true;
     }
 
+    // Native base is setting these props, which are deprecated by react-native-web
+    if (message.startsWith('"shadow*" style props are deprecated. Use "boxShadow"')) return true;
+    if (message.startsWith('accessibilityLabel is deprecated. Use aria-label.')) return true;
+    if (message.startsWith('editable is deprecated. Use readOnly.')) return true;
+    if (message.startsWith('props.pointerEvents is deprecated. Use style.pointerEvents')) return true;
+    // Native base does not support role prop and needs accessibilityRole which is deprecated by react-native-web
+    if (message.startsWith('accessibilityRole is deprecated. Use role.')) return true;
+
     return false;
   },
 });


### PR DESCRIPTION
### Context

react-native web deprecated multiples props, but native-base is either settings these props or not supporting the same as rnw so we need to silence the warnings.

https://github.com/necolas/react-native-web/pull/2377/