### PR TITLE
feat(lerna-config): disable emit declaration cache when tsconfig has no references [no issue]

### DIFF
--- a/@ornikar/lerna-config/bin/generate-tsconfig-files.mjs
+++ b/@ornikar/lerna-config/bin/generate-tsconfig-files.mjs
@@ -87,6 +87,7 @@ import { getGraphPackages } from '../index.mjs';
       if (!hasReferences) {
         compilerOptions.noEmit = true;
         delete compilerOptions.emitDeclarationOnly;
+        delete filteredCurrentCompilerOptions.emitDeclarationOnly;
       } else {
         compilerOptions.noEmit = false;
         compilerOptions.emitDeclarationOnly = true;
@@ -95,6 +96,7 @@ import { getGraphPackages } from '../index.mjs';
       Object.keys(compilerOptions).forEach((key) => {
         delete filteredCurrentCompilerOptions[key];
       });
+
       if (!isApp) {
         delete compilerOptions.baseUrl;
       }

--- a/@ornikar/lerna-config/bin/generate-tsconfig-files.mjs
+++ b/@ornikar/lerna-config/bin/generate-tsconfig-files.mjs
@@ -69,10 +69,10 @@ import { getGraphPackages } from '../index.mjs';
         moduleDetection: 'force',
         noEmit: false,
         noEmitOnError: true,
-        outDir: `../../node_modules/.cache/tsc/${pkg.name}`,
-        tsBuildInfoFile: `../../node_modules/.cache/tsc/${pkg.name}/tsbuildinfo`,
         declaration: true,
         declarationMap: true,
+        outDir: `../../node_modules/.cache/tsc/${pkg.name}`,
+        tsBuildInfoFile: `../../node_modules/.cache/tsc/${pkg.name}/tsbuildinfo`,
       };
 
       const hasReferences = tsPackages.some((lernaPkg) => {
@@ -86,6 +86,7 @@ import { getGraphPackages } from '../index.mjs';
 
       if (!hasReferences) {
         compilerOptions.noEmit = true;
+        delete compilerOptions.emitDeclarationOnly;
       } else {
         compilerOptions.noEmit = false;
         compilerOptions.emitDeclarationOnly = true;
@@ -143,6 +144,9 @@ import { getGraphPackages } from '../index.mjs';
       if (!hasReferences) {
         tsconfigBuildContent.compilerOptions.noEmit = false;
         tsconfigBuildContent.compilerOptions.emitDeclarationOnly = true;
+      } else {
+        delete tsconfigBuildContent.compilerOptions.noEmit;
+        delete tsconfigBuildContent.compilerOptions.emitDeclarationOnly;
       }
 
       // react-scripts doesn't like paths


### PR DESCRIPTION
tsc has cache enabled. Each package references other packages needed (same as dependencies) and tsc only build once and reuse built declarations.
However, we don't need to build declaration if the package is not reused as a dependency