### PR TITLE
feat(repo-config): add support for simple node test runner prepush hook [no issue]

### DIFF
--- a/@ornikar/repo-config/lib/postinstall/install-husky.js
+++ b/@ornikar/repo-config/lib/postinstall/install-husky.js
@@ -148,12 +148,16 @@ fi
   const prePushHook = [];
 
   if (shouldRunTest()) {
-    prePushHookPreCommands.push(
-      '# autodetect main branch (usually master or main)',
-      'mainBranch=$(LANG=en_US git remote show origin | grep "HEAD branch" | cut -d\' \' -f5)',
-      '',
-    );
-    prePushHook.push(`CI=true ${pm.name} test --changedSince=origin/$mainBranch`);
+    if (pkg.scripts.test === 'node --test') {
+      prePushHook.push(`CI=true ${pm.name} test`);
+    } else {
+      prePushHookPreCommands.push(
+        '# autodetect main branch (usually master or main)',
+        'mainBranch=$(LANG=en_US git remote show origin | grep "HEAD branch" | cut -d\' \' -f5)',
+        '',
+      );
+      prePushHook.push(`CI=true ${pm.name} test --changedSince=origin/$mainBranch`);
+    }
   }
 
   if (shouldRunChecks()) {


### PR DESCRIPTION
### Context

Very simple tests in eslint-configs that does not requires jest.

### Solution

Use of https://nodejs.org/api/test.html available since node 18 (we're not there yet but very very close)