### PR TITLE
fix: jest-config-react-native storybook mock stories unmount after test [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
+++ b/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
@@ -79,6 +79,7 @@ exports.storiesOf = (groupName) => {
           const rtlApi = render(story(context), { wrapper: WrappingComponent });
           if (waitForExpectation) await waitFor(() => waitForExpectation(rtlApi, expect, { parameters }));
           expect(rtlApi.toJSON()).toMatchSnapshot();
+          rtlApi.unmount();
         });
       });
 


### PR DESCRIPTION
Similar to the unmount already existing for the web mocks, this fixes leaks and errors due to hooks/effects/animation on mounted compoment after the end of the test
