### PR TITLE
fix: storybook mocks should be in testSetupAfterEnv to make sure testing-library is cleanup properly [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
+++ b/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
@@ -2,6 +2,12 @@
 
 'use strict';
 
+if (!global.afterAll) {
+  throw new Error(
+    'Missing afterAll global in mock @storybook/react-native. Please check your jest test-setup and make sure you use testSetupAfterEnv.',
+  );
+}
+
 const decorateStory = (storyFn, decorators) =>
   // eslint-disable-next-line unicorn/no-array-reduce
   decorators.reduce(
@@ -79,7 +85,6 @@ exports.storiesOf = (groupName) => {
           const rtlApi = render(story(context), { wrapper: WrappingComponent });
           if (waitForExpectation) await waitFor(() => waitForExpectation(rtlApi, expect, { parameters }));
           expect(rtlApi.toJSON()).toMatchSnapshot();
-          rtlApi.unmount();
         });
       });
 

--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -2,6 +2,12 @@
 
 'use strict';
 
+if (!global.afterAll) {
+  throw new Error(
+    'Missing afterAll global in mock @storybook/react. Please check your jest test-setup and make sure you use testSetupAfterEnv.',
+  );
+}
+
 const decorateStory = (storyFn, decorators) =>
   // eslint-disable-next-line unicorn/no-array-reduce
   decorators.reduce(
@@ -76,12 +82,11 @@ exports.storiesOf = (groupName) => {
             : ({ children }) => decorateStory(() => children, [...localDecorators, ...globalDecorators])(context);
 
           const rtlApi = render(story(context), { wrapper: wrappingComponent });
-          const { unmount, asFragment } = rtlApi;
+          const { asFragment } = rtlApi;
           if (waitForExpectation) {
             await waitFor(() => waitForExpectation(rtlApi, expect, { parameters }));
           }
           expect(asFragment()).toMatchSnapshot();
-          unmount();
         });
       });
 


### PR DESCRIPTION
When testing-library is loaded, it checks for an `afterAll` to add the cleanup step.
But when we load decorators in the test-setup, as it's in early initialization, jest has not yet initialized the hooks. So, no cleanup
I made a fix that obsiously did not work properly: https://github.com/ornikar/shared-configs/pull/804 maybe because jest parses `require`s ?

Example on react-native tests (`yarn test:native --no-cache`):
BEFORE: 48.661s
AFTER: 35.993s

Example on web tests (`yarn test:web --no-cache`):
BEFORE: 203.242s
AFTER: 164.08s