### PR TITLE
feat(babel-preset-kitt-universal)!: disable styled-components plugins by default [no issue]

### DIFF
--- a/@ornikar/babel-preset-kitt-universal/lib/__tests_fixtures__/web-simple-tag.js
+++ b/@ornikar/babel-preset-kitt-universal/lib/__tests_fixtures__/web-simple-tag.js
@@ -3,6 +3,7 @@
 exports.presetOptions = {
   isWeb: true,
   enableStyledComponentsReactNativeImport: true,
+  enableLegacyStyledComponents: true,
   styledComponentsOptions: { ssr: false },
 };
 

--- a/@ornikar/babel-preset-kitt-universal/lib/__tests_fixtures__/web-with-linaria.js
+++ b/@ornikar/babel-preset-kitt-universal/lib/__tests_fixtures__/web-with-linaria.js
@@ -2,6 +2,7 @@
 
 exports.presetOptions = {
   isWeb: true,
+  enableLegacyStyledComponents: true,
   enableStyledComponentsReactNativeImport: true,
   styledComponentsOptions: { ssr: false },
 };

--- a/@ornikar/babel-preset-kitt-universal/lib/__tests_fixtures__/web-with-react-refresh-and-linaria.js
+++ b/@ornikar/babel-preset-kitt-universal/lib/__tests_fixtures__/web-with-react-refresh-and-linaria.js
@@ -4,6 +4,7 @@
 
 exports.presetOptions = {
   isWeb: true,
+  enableLegacyStyledComponents: true,
   enableStyledComponentsReactNativeImport: true,
   styledComponentsOptions: { ssr: false },
 };

--- a/@ornikar/babel-preset-kitt-universal/lib/__tests_fixtures__/web-with-react-refresh.js
+++ b/@ornikar/babel-preset-kitt-universal/lib/__tests_fixtures__/web-with-react-refresh.js
@@ -4,6 +4,7 @@
 
 exports.presetOptions = {
   isWeb: true,
+  enableLegacyStyledComponents: true,
   enableStyledComponentsReactNativeImport: true,
   styledComponentsOptions: { ssr: false },
 };

--- a/@ornikar/babel-preset-kitt-universal/lib/index.js
+++ b/@ornikar/babel-preset-kitt-universal/lib/index.js
@@ -10,12 +10,18 @@ const checkIsWebOption = (opts) => {
 
 module.exports = function preset(context, opts = {}) {
   checkIsWebOption(opts);
-  const { isWeb, styledComponentsOptions, enableStyledComponentsReactNativeImport, disableLinaria = !isWeb } = opts;
+  const {
+    isWeb,
+    styledComponentsOptions,
+    enableStyledComponentsReactNativeImport,
+    disableLinaria = !isWeb,
+    enableLegacyStyledComponents = false,
+  } = opts;
 
   return {
     plugins: [
       disableLinaria && 'babel-plugin-linaria-css-to-undefined',
-      [
+      enableLegacyStyledComponents && [
         'babel-plugin-styled-components',
         {
           ssr: isWeb,
@@ -26,7 +32,9 @@ module.exports = function preset(context, opts = {}) {
           ...styledComponentsOptions,
         },
       ],
-      enableStyledComponentsReactNativeImport && 'babel-plugin-styled-components-react-native-web',
+      enableLegacyStyledComponents &&
+        enableStyledComponentsReactNativeImport &&
+        'babel-plugin-styled-components-react-native-web',
       isWeb && ['babel-plugin-react-native', { OS: 'web' }],
     ].filter(Boolean),
   };


### PR DESCRIPTION
### Context

We deprecated styled-components and mostly no longer use it

### Solution

Keep it while we still use it but disabled by default.