### PR TITLE
fix: fix unmount on stories tests [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
+++ b/@ornikar/jest-config-react-native/__mocks__/@storybook/react-native.jsx
@@ -85,6 +85,7 @@ exports.storiesOf = (groupName) => {
           const rtlApi = render(story(context), { wrapper: WrappingComponent });
           if (waitForExpectation) await waitFor(() => waitForExpectation(rtlApi, expect, { parameters }));
           expect(rtlApi.toJSON()).toMatchSnapshot();
+          rtlApi.unmount();
         });
       });
 

--- a/@ornikar/jest-config-react/__mocks__/@storybook/react.js
+++ b/@ornikar/jest-config-react/__mocks__/@storybook/react.js
@@ -82,11 +82,11 @@ exports.storiesOf = (groupName) => {
             : ({ children }) => decorateStory(() => children, [...localDecorators, ...globalDecorators])(context);
 
           const rtlApi = render(story(context), { wrapper: wrappingComponent });
-          const { asFragment } = rtlApi;
           if (waitForExpectation) {
             await waitFor(() => waitForExpectation(rtlApi, expect, { parameters }));
           }
-          expect(asFragment()).toMatchSnapshot();
+          expect(rtlApi.asFragment()).toMatchSnapshot();
+          rtlApi.unmount();
         });
       });
 


### PR DESCRIPTION
### Context

Cleanup is not ran just after tests but after tasks are finished

![image](https://github.com/ornikar/shared-configs/assets/302891/969295c2-c591-4bdf-b30c-e92899745baf)

However with snapshots and stories, we want to unmount as soon as possible to avoid other animations and effects to happen and fail our tests due to not using `act`.

### Solution

use unmount