### PR TITLE
fix: get relative path from extract translations file [no issue]

### DIFF
--- a/@ornikar/intl-config/extract-translations.js
+++ b/@ornikar/intl-config/extract-translations.js
@@ -10,6 +10,8 @@ process.env.NODE_ENV = 'production';
 
 const sortFn = ([a], [b]) => a.toLowerCase().localeCompare(b.toLowerCase());
 
+const cwd = process.cwd()
+
 module.exports = ({ paths, babelPluginFormatjsOptions = {}, defaultDestinationDirectory }) => {
   const projectCollection = {};
   const phraseSources = [];
@@ -32,10 +34,12 @@ module.exports = ({ paths, babelPluginFormatjsOptions = {}, defaultDestinationDi
             ...babelPluginFormatjsOptions,
             onMsgExtracted(filename, descriptors) {
               if (descriptors.length === 0) return;
-              // eslint-disable-next-line security/detect-non-literal-regexp
+
+              const relativeFilename = path.relative(cwd, filename);
               const filenameRegExp = new RegExp(
-                `${filename.split('.')[0]}\\.((web|ios|android)\\.)*${filename.split('.').at(-1)}`,
+                `${relativeFilename.split('.')[0]}\\.((web|ios|android)\\.)*${relativeFilename.split('.').at(-1)}`,
               );
+
               descriptors.forEach(({ id, defaultMessage }) => {
                 if (
                   id in projectCollection &&

--- a/@ornikar/intl-config/extract-translations.js
+++ b/@ornikar/intl-config/extract-translations.js
@@ -10,7 +10,7 @@ process.env.NODE_ENV = 'production';
 
 const sortFn = ([a], [b]) => a.toLowerCase().localeCompare(b.toLowerCase());
 
-const cwd = process.cwd()
+const cwd = process.cwd();
 
 module.exports = ({ paths, babelPluginFormatjsOptions = {}, defaultDestinationDirectory }) => {
   const projectCollection = {};
@@ -36,6 +36,7 @@ module.exports = ({ paths, babelPluginFormatjsOptions = {}, defaultDestinationDi
               if (descriptors.length === 0) return;
 
               const relativeFilename = path.relative(cwd, filename);
+              // eslint-disable-next-line security/detect-non-literal-regexp
               const filenameRegExp = new RegExp(
                 `${relativeFilename.split('.')[0]}\\.((web|ios|android)\\.)*${relativeFilename.split('.').at(-1)}`,
               );


### PR DESCRIPTION
### Context

The extract-translations file contains a filename check to avoid duplicates. The absolute path is checked. However, if this has a dot before the file extension, the check is not correct. 

### Solution

Use relative filename path instead. 
