### PR TITLE
fix(jest-config-react-native): add library not compatible with sucrase for expo 49 [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/customTransforms.js
+++ b/@ornikar/jest-config-react-native/customTransforms.js
@@ -6,7 +6,7 @@
 
 exports.customTransforms = {
   // compilation of problematic node_modules has a simpler babel config
-  'node_modules/(react-native-(calendars|reanimated)|@react-native-community/netinfo)/.*\\.(js|jsx|ts|tsx)$':
+  'node_modules/(react-native-(calendars|reanimated)|@react-native-community/netinfo|@react-native/virtualized-lists)/.*\\.(js|jsx|ts|tsx)$':
     require.resolve('./transformers/babel-transformer-node-modules.js'),
 
   // dont transform node_modules when already compiled


### PR DESCRIPTION
### Context

Update to expo 49

`@react-native/virtualized-lists` is not compatible with sucrase, throws this error: "TypeError: Cannot redefine property: state"

### Solution

Add to libraries going through babel instead of sucrase