### PR TITLE
feat(webpack-config): add support for entries [no issue]

### DIFF
--- a/@ornikar/webpack-config/workspaceAliases.js
+++ b/@ornikar/webpack-config/workspaceAliases.js
@@ -24,6 +24,14 @@ module.exports = (webpackConfig, { srcDirectory = './src' } = {}) => {
       // eslint-disable-next-line security/detect-non-literal-fs-filename
       const isTs = fs.existsSync(path.resolve(`${basePath}.ts`));
       workspaceAliases[`${childPkg.name}$`] = path.resolve(`${basePath}.${isTs ? 'ts' : 'js'}`);
+      if (childPkg.ornikar?.entries) {
+        childPkg.ornikar?.entries.forEach((entryName) => {
+          if (entryName === 'index') return;
+          workspaceAliases[`${childPkg.name}/${entryName}$`] = path.resolve(
+            `${path.join(packageSrcDirectory, entryName)}.${isTs ? 'ts' : 'js'}`,
+          );
+        });
+      }
     });
   }
 


### PR DESCRIPTION
### Context

Add support for HMR with entries in monorepos.

Examples: `@ornikar/kitt-icons/phosphor` ; `@ornikar/runtime-app/sentry`.