### PR TITLE
fix(commitlint-config): remove max length not in specification

### DIFF
--- a/@ornikar/commitlint-config/index.js
+++ b/@ornikar/commitlint-config/index.js
@@ -6,5 +6,9 @@ module.exports = {
     // disable scope case
     // We use camelCase in directory names, and scope should match these directories in some cases.
     'scope-case': [0],
+
+    // not in the spec, see https://www.conventionalcommits.org/en/v1.0.0/#specification
+    'header-max-length': [0],
+    'footer-max-line-length': [0],
   },
 };


### PR DESCRIPTION
### Context

Commitlint sometimes prevents us from commiting because we wrote too much text.
However, the max length is not in the official spec. This is an addition by the commitlint team, at that time different than the standard changelog team
Also, it's better to write too much text than giving up and not writing it. In particular, the length of the body is not important at all beacause it will be wrapped by the terminal or github.

### Solution

Remove the restriction on line length for both header and footer
