### PR TITLE
feat: add reanimated transform for ornikar packages on jest [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/customTransforms.js
+++ b/@ornikar/jest-config-react-native/customTransforms.js
@@ -5,6 +5,10 @@
  */
 
 exports.customTransforms = {
+  // compilation of ornikar packages
+  'node_modules/@ornikar/kitt-universal/.*\\.(js|cjs|mjs)$':
+    require.resolve('./transformers/babel-transformer-ornikar-packages.js'),
+
   // compilation of problematic node_modules has a simpler babel config
   'node_modules/(react-native-(calendars|reanimated)|@react-native-community/netinfo|@react-native/virtualized-lists)/.*\\.(js|jsx|ts|tsx)$':
     require.resolve('./transformers/babel-transformer-node-modules.js'),

--- a/@ornikar/jest-config-react-native/customTransforms.js
+++ b/@ornikar/jest-config-react-native/customTransforms.js
@@ -6,9 +6,7 @@
 
 exports.customTransforms = {
   // compilation of ornikar packages
-  'node_modules/@ornikar/kitt-universal/.*\\.(js|cjs|mjs)$': require.resolve(
-    './transformers/babel-transformer-ornikar-packages.js',
-  ),
+  'node_modules/@ornikar/.*\\.(js|cjs|mjs)$': require.resolve('./transformers/babel-transformer-ornikar-packages.js'),
 
   // compilation of problematic node_modules has a simpler babel config
   'node_modules/(react-native-(calendars|reanimated)|@react-native-community/netinfo|@react-native/virtualized-lists)/.*\\.(js|jsx|ts|tsx)$':

--- a/@ornikar/jest-config-react-native/customTransforms.js
+++ b/@ornikar/jest-config-react-native/customTransforms.js
@@ -6,8 +6,9 @@
 
 exports.customTransforms = {
   // compilation of ornikar packages
-  'node_modules/@ornikar/kitt-universal/.*\\.(js|cjs|mjs)$':
-    require.resolve('./transformers/babel-transformer-ornikar-packages.js'),
+  'node_modules/@ornikar/kitt-universal/.*\\.(js|cjs|mjs)$': require.resolve(
+    './transformers/babel-transformer-ornikar-packages.js',
+  ),
 
   // compilation of problematic node_modules has a simpler babel config
   'node_modules/(react-native-(calendars|reanimated)|@react-native-community/netinfo|@react-native/virtualized-lists)/.*\\.(js|jsx|ts|tsx)$':

--- a/@ornikar/jest-config-react-native/jest-preset.js
+++ b/@ornikar/jest-config-react-native/jest-preset.js
@@ -22,7 +22,7 @@ module.exports = {
   testEnvironmentOptions: expoPreset.testEnvironmentOptions || {},
   // override expo transformIgnorePatterns with custom config
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native.*|@react-native.*|expo.*|@expo(nent)?/.*|react-navigation.*|@react-navigation/.*|native-base)/)',
+    'node_modules/(?!(react-native.*|@react-native.*|expo.*|@expo(nent)?/.*|react-navigation.*|@react-navigation/.*|native-base|@ornikar/.*)/)',
   ],
   transform: {
     ...customTransforms,

--- a/@ornikar/jest-config-react-native/transformers/babel-transformer-ornikar-packages.js
+++ b/@ornikar/jest-config-react-native/transformers/babel-transformer-ornikar-packages.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+const babelJest = require('babel-jest').default;
+
+module.exports = babelJest.createTransformer({
+  plugins: ['react-native-reanimated/plugin'],
+  babelrc: false,
+  configFile: false,
+});


### PR DESCRIPTION
### Context

The new rollup config created an issue with jest where the reanimated plugin wasn't applied on our packages.

- Added a custom transform to apply the reanimated plugin on our packages
- Excluded our packages from the transformIgnorePatterns