### PR TITLE
fix: ornikar package custom transform [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/customTransforms.js
+++ b/@ornikar/jest-config-react-native/customTransforms.js
@@ -6,7 +6,9 @@
 
 exports.customTransforms = {
   // compilation of ornikar packages
-  'node_modules/@ornikar/.*\\.(js|cjs|mjs)$': require.resolve('./transformers/babel-transformer-ornikar-packages.js'),
+  'node_modules/@ornikar/(.[a-z-]*)/dist/.*\\.(js|cjs|mjs)$': require.resolve(
+    './transformers/babel-transformer-ornikar-packages.js',
+  ),
 
   // compilation of problematic node_modules has a simpler babel config
   'node_modules/(react-native-(calendars|reanimated)|@react-native-community/netinfo|@react-native/virtualized-lists)/.*\\.(js|jsx|ts|tsx)$':


### PR DESCRIPTION
### Context

This transform was added to pass the reanimated plugin on the files created by rollup (since we don't pass the reanimated plugin on the file when rollup does the transform)
The regex was too permissive and also included files from the node_modules of our packages.


### Solution

Changed the regex to only include files in the dist folder of our packages