### PR TITLE
feat: unify `jest` configs between insurance and education repositories [no issue]

### DIFF
--- a/@ornikar/jest-config-react-native/jest-preset.js
+++ b/@ornikar/jest-config-react-native/jest-preset.js
@@ -22,7 +22,7 @@ module.exports = {
   testEnvironmentOptions: expoPreset.testEnvironmentOptions || {},
   // override expo transformIgnorePatterns with custom config
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native.*|@react-native.*|expo.*|@expo(nent)?/.*|react-navigation.*|@react-navigation/.*|native-base|@ornikar/.*)/)',
+    'node_modules/(?!(react-native.*|@react-native.*|expo.*|@expo(nent)?/.*|react-navigation.*|@react-navigation/.*|native-base|@ornikar/.*)/|mixpanel-react-native|axios|solito)',
   ],
   transform: {
     ...customTransforms,

--- a/@ornikar/jest-config/jest-preset.js
+++ b/@ornikar/jest-config/jest-preset.js
@@ -18,12 +18,12 @@ module.exports = {
   testMatch: [
     // This first testMatch is used in jest-config-react
     `<rootDir>/${src}/**/__tests__/**/*.${useTypescript ? '{js,ts,tsx}' : 'js'}`,
-    `<rootDir>/${src}/**/*.test.${useTypescript ? '{js,ts,tsx}' : 'js'}`,
-    '<rootDir>/{config,scripts}/**/__tests__/**/*.test.js',
-    '<rootDir>/{config,scripts}/**/*.test.js',
+    `<rootDir>/${src}/**/*.(spec|test).${useTypescript ? '{js,ts,tsx}' : 'js'}`,
+    '<rootDir>/{config,scripts}/**/__tests__/**/*.(spec|test).js',
+    '<rootDir>/{config,scripts}/**/*.(spec|test).js',
   ],
   testPathIgnorePatterns: [],
-  moduleDirectories: useLerna ? ['node_modules', 'src'] : ['node_modules'],
+  moduleDirectories: ['node_modules', 'src'],
   modulePaths: useLerna ? [] : ['<rootDir>/src'],
   setupFiles: [
     require.resolve('./global-mocks.js'),


### PR DESCRIPTION
### Context

We want to unify our `jest` configurations.

### Solution

Extract configuration parts from insurance and education repositories that appear to be the same.

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- Uncomment this if you have a mixpanel dashboard related to this PR that allows us to track it in production
### Mixpanel dashboard

- Staging: Link
- Production: Link
-->
