### PR TITLE
feat: do not add pod-install if expo managed project [no issue]

### DIFF
--- a/@ornikar/repo-config/lib/postinstall/install-husky.js
+++ b/@ornikar/repo-config/lib/postinstall/install-husky.js
@@ -156,12 +156,16 @@ fi
       }
 
       const podfilePath = path.join(packageLocation, 'ios/Podfile.lock');
+
       if (fs.existsSync(podfilePath)) {
-        postHookContent += `
-if [ -n "$(git diff HEAD@{1}..HEAD@{0} -- ${podfilePath})" ]; then
-  ${[cdToPackageLocation, 'yarn pod-install || true', cdToRoot].filter(Boolean).join('\n  ')}
-fi
-      `;
+        const gitIgnorePath = path.join(packageLocation, '.gitignore');
+        if (fs.existsSync(gitIgnorePath) && !fs.readFileSync(gitIgnorePath, 'utf8').includes('/ios/')) {
+          postHookContent += `
+  if [ -n "$(git diff HEAD@{1}..HEAD@{0} -- ${podfilePath})" ]; then
+    ${[cdToPackageLocation, 'yarn pod-install || true', cdToRoot].filter(Boolean).join('\n  ')}
+  fi
+        `;
+        }
       }
     });
     writeHook('post-checkout', postHookContent);


### PR DESCRIPTION
### Context

ne pas ajouter l'installation des dépendences iOS si jamais le dossier iOS est dans le gitIgnore (expo managed)