### PR TITLE
fix: husky pod install rules [no issue]

### DIFF
--- a/@ornikar/repo-config/lib/postinstall/install-husky.js
+++ b/@ornikar/repo-config/lib/postinstall/install-husky.js
@@ -159,7 +159,7 @@ fi
 
       if (fs.existsSync(podfilePath)) {
         const gitIgnorePath = path.join(packageLocation, '.gitignore');
-        if (fs.existsSync(gitIgnorePath) && !fs.readFileSync(gitIgnorePath, 'utf8').includes('/ios/')) {
+        if (fs.existsSync(gitIgnorePath) && !fs.readFileSync(gitIgnorePath, 'utf8').includes('/ios/\n')) {
           postHookContent += `
   if [ -n "$(git diff HEAD@{1}..HEAD@{0} -- ${podfilePath})" ]; then
     ${[cdToPackageLocation, 'yarn pod-install || true', cdToRoot].filter(Boolean).join('\n  ')}


### PR DESCRIPTION
### Context

`/ios/` était trop flex, ça supprimait également le script pod install dans la learner-apps car elle contient un. `/ios/Pods` dans son gitignore

### Test

- testé sur learner-apps et INA (branche expo prebuild)
