### PR TITLE
fix: add not dead to browserlist config [no issue]

### DIFF
--- a/@ornikar/browserslist-config/README.md
+++ b/@ornikar/browserslist-config/README.md
@@ -14,7 +14,7 @@ in `package.json`:
 
 ## Supported browsers
 
-- Degraded support: https://browserl.ist/?q=last+4+versions%2C+%3E+.2%25+in+FR%2C+Firefox+ESR%2C+not+ie+%3C+10%2C+not+ios+%3C+10%2C+not+op_mini+all
-- Full support: https://browserl.ist/?q=last+4+versions%2C+%3E+1%25+in+FR%2C+Firefox+ESR%2C+not+ie+%3C+12%2C+not+op_mini+all
+- Degraded support: https://browsersl.ist/#q=last+4+versions%2C+%3E+.2%25+in+FR%2C+Firefox+ESR%2C+not+ie+%3C+10%2C+not+ios+%3C+10%2C+not+op_mini+all%2C+not+dead
+- Full support: https://browsersl.ist/#q=last+4+versions%2C+%3E+1%25+in+FR%2C+Firefox+ESR%2C+not+ie+%3C+12%2C+not+op_mini+all%2C+not+dead
 
 Degraded support: the website must be usable but don't have to be pixel perfect or pretty.

--- a/@ornikar/browserslist-config/degraded-support.js
+++ b/@ornikar/browserslist-config/degraded-support.js
@@ -2,4 +2,4 @@
 
 // Note: if you update this, update the link in README.md !
 
-module.exports = 'last 4 versions, > .2% in FR, Firefox ESR, not ie < 10, not ios < 10, not op_mini all'.split(',');
+module.exports = 'last 4 versions, > .2% in FR, Firefox ESR, not ie < 10, not ios < 10, not op_mini all, not dead'.split(',');

--- a/@ornikar/browserslist-config/full-support.js
+++ b/@ornikar/browserslist-config/full-support.js
@@ -2,4 +2,4 @@
 
 // Note: if you update this, update the link in README.md !
 
-module.exports = 'last 4 versions, > 1% in FR, Firefox ESR, not ie < 12, not op_mini all'.split(',');
+module.exports = 'last 4 versions, > 1% in FR, Firefox ESR, not ie < 12, not op_mini all, not dead'.split(',');


### PR DESCRIPTION
### Context

L'upgrade de mapbox-gl entre en conflit avec des versions mobiles encore supportées de notre côté

### Solution

Exclusion des `dead` browsers 

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- Uncomment this if you have a mixpanel dashboard related to this PR that allows us to track it in production
### Mixpanel dashboard

- Staging: Link
- Production: Link
-->
