### PR TITLE
feat(jest-config): remove dates related setup  OSE-16622

### DIFF
--- a/@ornikar/jest-config/global-mocks.js
+++ b/@ornikar/jest-config/global-mocks.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const mockdate = require('mockdate');
+// const mockdate = require('mockdate');
 
-mockdate.set('2018-07-30T08:52:42.679Z');
+// mockdate.set('2018-07-30T08:52:42.679Z');
 
 // Mock getFullYear
 Date.getFullYear = () => 2019;

--- a/@ornikar/jest-config/jest-preset.js
+++ b/@ornikar/jest-config/jest-preset.js
@@ -31,7 +31,7 @@ module.exports = {
     '<rootDir>/test-setup.js',
   ],
   setupFilesAfterEnv: [require.resolve('./test-setup-after-env')],
-  globalSetup: require.resolve('./jest-global-setup.js'),
+  // globalSetup: require.resolve('./jest-global-setup.js'),
   clearMocks: true,
   // Explicitly set both reset/restoreMocks as their default
   // See https://github.com/ornikar/shared-configs/pull/820#discussion_r1034570609


### PR DESCRIPTION
### Context
The current Jest setup for date mocking prevents us from properly testing date calculations across different timezones.
This PR aims to move that setup to our product repositories to see if it can be locally overridden.

⚠️ DO NOT MERGE

### Solution

<!-- Explain here the solution you chose for this -->

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->

<!-- Uncomment this if you have a mixpanel dashboard related to this PR that allows us to track it in production
### Mixpanel dashboard

- Staging: Link
- Production: Link
-->
