### PR TITLE
chore: disable install lifecycle scripts [OSE-20201]

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,12 @@ compressionLevel: 0
 
 enableGlobalCache: false
 
+# Disable install lifecycle scripts globally. Only packages explicitly
+# allowlisted in package.json#dependenciesMeta[pkg].built will run them.
+# Mitigates supply-chain attacks that rely on malicious postinstall
+# scripts (e.g. Shai-Hulud, event-stream).
+enableScripts: false
+
 nodeLinker: node-modules
 
 npmRegistryServer: 'https://registry.npmjs.org'

--- a/package.json
+++ b/package.json
@@ -38,5 +38,10 @@
     "lint-staged": "15.5.2",
     "prettier": "2.8.8"
   },
+  "dependenciesMeta": {
+    "unrs-resolver": {
+      "built": true
+    }
+  },
   "packageManager": "yarn@4.13.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,6 +3542,9 @@ __metadata:
     jest-environment-jsdom: "npm:30.0.0"
     lint-staged: "npm:15.5.2"
     prettier: "npm:2.8.8"
+  dependenciesMeta:
+    unrs-resolver:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Context

Applies the same supply-chain hardening as [ornikar/instructors-app#4177](https://github.com/ornikar/instructors-app/pull/4177) (reference) and [ornikar/orb-frontend#220](https://github.com/ornikar/orb-frontend/pull/220) (sibling) to this repo.

Yarn Berry runs install lifecycle scripts (`preinstall`/`install`/`postinstall`) by default. Recent supply-chain attacks — **Shai-Hulud**, **event-stream** — abuse these scripts to execute malicious code during `yarn install`. Setting `enableScripts: false` globally disables them; individual packages that legitimately need to build can be opted in via `package.json#dependenciesMeta[pkg].built = true`.

Ticket: OSE-20201

## Changes

- `.yarnrc.yml` — add `enableScripts: false` with an explanatory comment
- `package.json` — `dependenciesMeta` allowlist (see below)

## Allowlisted packages

- `unrs-resolver` — native-binary resolver used by eslint-plugin-import; build script downloads the platform-specific binary

`core-js-pure` also lists build scripts but they're informational (funding message) — left disabled.

## Test plan

- [x] `yarn install` from clean state — no skipped-build warnings
- [x] CI green on this branch

## Note

Commit scope omitted (`chore:` rather than `chore(security):`) because repo's commitlint config only allows per-package scopes. PR title follows the same convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)