### PR TITLE
ci: add Claude review workflow [no-issue]

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,27 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    if: |
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.draft == false &&
+       github.event.pull_request.user.login != 'ornikar-renovate[bot]' &&
+       github.event.pull_request.user.login != 'renovate[bot]' &&
+       github.event.pull_request.user.login != 'dependabot[bot]') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude') &&
+       github.event.comment.user.type != 'Bot')
+    uses: ornikar/.github/.github/workflows/claude-pr-review.yml@master
+    secrets: inherit
+    with:
+      plugins: |
+        common-plugin@ornikar-plugins
+        edu-frontend-plugin@ornikar-plugins
+        common-frontend-plugin@ornikar-plugins


### PR DESCRIPTION
## Context

Enable automated Claude code review on PRs in this repository, matching the setup already in place on other Ornikar repos. The reusable workflow is maintained centrally in [ornikar/.github](https://github.com/ornikar/.github/blob/master/.github/workflows/claude-pr-review.yml).

**The required Anthropic secret has already been added to this project**, so `secrets: inherit` will resolve correctly once this workflow lands.

## Impact

No breaking changes.

## Testing Plan

- This PR itself serves as the end-to-end test: once it is marked ready for review, the `Claude PR Review` job should trigger on the `ready_for_review` event and post a review, confirming the secret is correctly wired.

## Useful links

- [Shared package contribution guidelines](https://www.notion.so/Shared-packages-contribution-guidelines-2b944a9797c9800db906eb4f5384c3f2)
- [Pull request and code review guidelines](https://www.notion.so/Pull-Request-Code-Review-25644a9797c98105971ff40a2031a27c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)