### PR TITLE
refactor(repo-config): detect monorepo via workspaces instead of lerna

### DIFF
--- a/@ornikar/monorepo-config/bin/generate-eslintrc-files.mjs
+++ b/@ornikar/monorepo-config/bin/generate-eslintrc-files.mjs
@@ -65,9 +65,6 @@ const generateAndWritePackageSourceConfig = async (configPath, prettierOptions, 
         root: true,
 
         parser: '@typescript-eslint/parser',
-        parserOptions: {
-          project: `${packagePath}/tsconfig.eslint.json`,
-        },
       },
       callback: (configParam) => {
         const config = { ...configParam };
@@ -86,8 +83,8 @@ const generateAndWritePackageSourceConfig = async (configPath, prettierOptions, 
         if (!config.settings) config.settings = {};
 
         config.settings['import/resolver'] = {
-          node: {
-            moduleDirectory: ['node_modules', 'src'],
+          typescript: {
+            project: `${packagePath}/tsconfig.json`,
           },
         };
 

--- a/@ornikar/repo-config/createLintStagedConfig.js
+++ b/@ornikar/repo-config/createLintStagedConfig.js
@@ -6,10 +6,10 @@ const path = require('node:path');
 // eslint-disable-next-line import/no-dynamic-require
 const pkg = require(path.resolve('package.json'));
 const workspaces = pkg.workspaces || false;
-const isLernaRepo = Boolean(pkg.devDependencies && pkg.devDependencies.lerna);
+const isMonoRepo = Boolean(workspaces && workspaces.length > 0);
 const hasTypescript = Boolean(pkg.devDependencies && pkg.devDependencies.typescript);
 const hasDeprecatedStylelint = Boolean(pkg.devDependencies && pkg.devDependencies.stylelint);
-const shouldGenerateTsconfigInLernaRepo = isLernaRepo && hasTypescript;
+const shouldGenerateTsconfigInMonoRepo = isMonoRepo && hasTypescript;
 const shouldRunCheckPkgJSScript = fs.existsSync('./scripts/check-packagejson.js');
 const shouldRunCheckPkgMJSScript = fs.existsSync('./scripts/check-packagejson.mjs');
 
@@ -32,9 +32,8 @@ module.exports = function createLintStagedConfig(options = {}) {
       return [
         'yarn dedupe',
         packagejsonFilenames.length === 0 ? undefined : `prettier --write ${packagejsonFilenames.join(' ')}`,
-        isLernaRepo && require.resolve('@ornikar/monorepo-config/bin/generate-eslintrc-files.mjs'),
-        shouldGenerateTsconfigInLernaRepo &&
-          require.resolve('@ornikar/monorepo-config/bin/generate-tsconfig-files.mjs'),
+        isMonoRepo && require.resolve('@ornikar/monorepo-config/bin/generate-eslintrc-files.mjs'),
+        shouldGenerateTsconfigInMonoRepo && require.resolve('@ornikar/monorepo-config/bin/generate-tsconfig-files.mjs'),
         shouldRunCheckPkgJSScript && 'node ./scripts/check-packagejson.js',
         shouldRunCheckPkgMJSScript && 'node ./scripts/check-packagejson.mjs',
         'git add yarn.lock .yarn',


### PR DESCRIPTION
## Summary
- Rename `isLernaRepo` to `isMonoRepo` in `createLintStagedConfig.js` and derive it from the presence of `package.json` workspaces. Whether the repo uses lerna is no longer relevant — what matters is that it's a monorepo with workspaces.
- Rename the related `shouldGenerateTsconfigInLernaRepo` to `shouldGenerateTsconfigInMonoRepo`.
- In `generate-eslintrc-files.mjs`: switch the generated `import/resolver` from `node` to `typescript` (using each package's `tsconfig.json`) and drop the now-unused `parserOptions.project` referencing `tsconfig.eslint.json`.

## Test plan
- [ ] Verify lint-staged still triggers `generate-eslintrc-files.mjs` and `generate-tsconfig-files.mjs` in a workspaces-based monorepo
- [ ] Verify a non-monorepo (no `workspaces` in `package.json`) skips those scripts
- [ ] Verify generated `.eslintrc` files resolve imports correctly via the typescript resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)